### PR TITLE
Translate GitHub Action into poetry

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,9 +2,10 @@
 max-line-length = 100
 inline-quotes = "
 multiline-quotes = "
-ignore = E203,W503,F403
+ignore = E203,W503,F403,E266
 exclude = build, _build, .ipynb_checkpoints, .git, .venv
 per-file-ignores = 
-    __init__.py,__main__.py: F401  # imported but unused
-    test_datajoint_tools.py: F811  # redefinition of imports
+    **/__init__.py:F401
+    **/__main__.py:F401
+    test_datajoint_tools.py:F811
 

--- a/.flake8
+++ b/.flake8
@@ -2,5 +2,9 @@
 max-line-length = 100
 inline-quotes = "
 multiline-quotes = "
-ignore = E203,W503
-exclude = build, _build, .ipynb_checkpoints
+ignore = E203,W503,F403
+exclude = build, _build, .ipynb_checkpoints, .git, .venv
+per-file-ignores = 
+    __init__.py,__main__.py: F401  # imported but unused
+    test_datajoint_tools.py: F811  # redefinition of imports
+

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,11 +47,11 @@ jobs:
     - name: Run linting
       run: |
         # stop the build if there are python syntax errors or undefined names
-      poetry run  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        poetry run  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-      poetry run  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      poetry run  black . --check
-      poetry run  isort .
+        poetry run  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        poetry run  black . --check
+        poetry run  isort .
     - name: Run tests
       run: poetry run python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,31 +3,7 @@ name: Python package
 on: [push]
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - name: Load pip cache if exists
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip
-          restore-keys: ${{ runner.os }}-pip
-      - name: Install linters
-        run: python -m pip install black flake8 isort
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Lint with black
-        run: black . --check
-      - name: Lint with isort
-        run: isort .
-
-  testing:
+  lint-test:
 
     strategy:
       fail-fast: true
@@ -36,7 +12,6 @@ jobs:
         os-version: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.6.2", "3.7", "3.8", "3.9", "3.10"]
 
-    needs: linting
     runs-on: ${{ matrix.os-version }}
 
     steps:
@@ -63,6 +38,14 @@ jobs:
       run: poetry install --no-interaction --no-root
     - name: Install pyrfume
       run: poetry install --no-interaction
+    - name: Run linting
+      run: |
+        # stop the build if there are python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        black . --check
+        isort .
     - name: Run tests
       run: python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Install pyrfume
       run: poetry install --no-interaction
     - name: Run linting
+      shell: poetry shell
       run: |
         # stop the build if there are python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -53,5 +54,6 @@ jobs:
         black . --check
         isort .
     - name: Run tests
+      shell: poetry shell
       run: python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Add to system path
-      run: echo "/home/runner/.local/bin" >> $GITHUB_PATH
+      run: |
+        echo "$PATH"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Check path...
+      run: echo "$PATH"
     - name: Install and configure poetry
       uses: snok/install-poetry@v1
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os-version: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     runs-on: ${{ matrix.os-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os-version: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.6.2", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6.7", "3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,9 +2,6 @@ name: Python package
 
 on: [push]
 
-env:
-  GET_POETRY_IGNORE_DEPRECATION: 1
-
 jobs:
   lint-test:
 
@@ -13,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os-version: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.6.7", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.os-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,33 +3,66 @@ name: Python package
 on: [push]
 
 jobs:
-  build:
-
+  linting:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Load pip cache if exists
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+          restore-keys: ${{ runner.os }}-pip
+      - name: Install linters
+        run: python -m pip install black flake8 isort
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint with black
+        run: black . --check
+      - name: Lint with isort
+        run: isort .
+
+  testing:
+
     strategy:
+      fail-fast: true
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        os-version: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.6.2", "3.7", "3.8", "3.9", "3.10"]
+
+    needs: linting
+    runs-on: ${{ matrix.os-version }}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Set up python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .
-        pip install rdkit-pypi
-    - name: Test with unit test
-      run: |
-        python -m pyrfume.unit_test 
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    
+	- name: Install and configure poetry
+	  uses: snok/install-poetry@v1
+	  with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+    - name: Install dependencies if cache doesn't exist
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+    - name: Install pyrfume
+      run: poetry install --no-interaction
+    - name: Run tests
+      run: python -m pyrfume.unit_test 
+

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Add to system path
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      run: echo "/home/runner/.local/bin" >> $GITHUB_PATH
     - name: Install and configure poetry
       uses: snok/install-poetry@v1
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,11 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Add to system path
-      run: |
-        echo "$PATH"
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-    - name: Check path...
-      run: echo "$PATH"
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
     - name: Install and configure poetry
       uses: snok/install-poetry@v1
       with:
@@ -47,11 +43,11 @@ jobs:
     - name: Run linting
       run: |
         # stop the build if there are python syntax errors or undefined names
-        poetry run  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .git,.venv
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        poetry run  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-        poetry run  black . --check
-        poetry run  isort .
+        poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .git,.venv
+        poetry run black . --check
+        poetry run isort .
     - name: Run tests
       run: poetry run python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install pyrfume
       run: poetry install --no-interaction
     - name: Run linting
-      shell: poetry shell
+      shell: bash -c "poetry run {0}"
       run: |
         # stop the build if there are python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -54,6 +54,6 @@ jobs:
         black . --check
         isort .
     - name: Run tests
-      shell: poetry shell
+      shell: bash -c "poetry run {0}"
       run: python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,10 +6,10 @@ jobs:
   lint-test:
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       max-parallel: 4
       matrix:
-        os-version: ["ubuntu-latest"]
+        os-version: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,15 +45,13 @@ jobs:
     - name: Install pyrfume
       run: poetry install --no-interaction
     - name: Run linting
-      shell: bash -c "poetry run {0}"
       run: |
         # stop the build if there are python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      poetry run  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-        black . --check
-        isort .
+      poetry run  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      poetry run  black . --check
+      poetry run  isort .
     - name: Run tests
-      shell: bash -c "poetry run {0}"
-      run: python -m pyrfume.unit_test 
+      run: poetry run python -m pyrfume.unit_test 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,10 +22,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Add to system path
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
     - name: Install and configure poetry
       uses: snok/install-poetry@v1
       with:
-        version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Load cached venv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       max-parallel: 4
       matrix:
-        os-version: ["ubuntu-latest", "macos-latest"]
+        os-version: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,6 +2,9 @@ name: Python package
 
 on: [push]
 
+env:
+  GET_POETRY_IGNORE_DEPRECATION: 1
+
 jobs:
   lint-test:
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,9 +47,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-	- name: Install and configure poetry
-	  uses: snok/install-poetry@v1
-	  with:
+    - name: Install and configure poetry
+      uses: snok/install-poetry@v1
+      with:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Load cached venv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Run linting
       run: |
         # stop the build if there are python syntax errors or undefined names
-        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .git,.venv
+        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .git,.venv
+        poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         poetry run black . --check
         poetry run isort .
     - name: Run tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install and configure poetry
       uses: snok/install-poetry@v1
       with:
+        version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Load cached venv

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ docs/make.bat
 config.ini
 /.venv/
 /.idea/
+*.swp
+

--- a/dash/cabinet/app/main.py
+++ b/dash/cabinet/app/main.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
-from dash.dependencies import Input, Output, State
-import flask
-import plotly.graph_objs as go
-import pandas as pd
-import pyrfume
 import sys
 
+import dash_core_components as dcc
+import dash_html_components as html
+import flask
+import pandas as pd
+import plotly.graph_objs as go
+from dash.dependencies import Input, Output, State
+
+import dash
+import pyrfume
 
 ##### Initialize app #####
 external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]

--- a/dash/cabinet/app/main.py
+++ b/dash/cabinet/app/main.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-import sys
 
 import dash_core_components as dcc
 import dash_html_components as html
 import flask
 import pandas as pd
 import plotly.graph_objs as go
-from dash.dependencies import Input, Output, State
 
 import dash
 import pyrfume
 
-##### Initialize app #####
+### Initialize app ###
 external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 app = flask.Flask(__name__)
 dapp = dash.Dash(
@@ -19,12 +17,12 @@ dapp = dash.Dash(
 )
 
 
-##### Load data #####
+### Load data ###
 file_path = pyrfume.DATA_DIR / "cabinets" / "Mainland Odor Cabinet with CIDs.csv"
 df = pd.read_csv(file_path).reset_index().groupby("CID").first()
 
 
-###### App layout ######
+### App layout ###
 dapp.layout = html.Div(
     [
         dcc.Graph(
@@ -55,6 +53,6 @@ dapp.layout = html.Div(
 )
 
 
-##### Run app #####
+### Run app ###
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/cabinet/app/main.py
+++ b/dash/cabinet/app/main.py
@@ -11,50 +11,49 @@ import sys
 
 
 ##### Initialize app #####
-external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 app = flask.Flask(__name__)
-dapp = dash.Dash(__name__,
-                server = app,
-                url_base_pathname = '/',
-                external_stylesheets=external_stylesheets)
+dapp = dash.Dash(
+    __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
+)
 
 
 ##### Load data #####
-file_path = pyrfume.DATA_DIR / 'cabinets' / 'Mainland Odor Cabinet with CIDs.csv'
-df = pd.read_csv(file_path).reset_index().groupby('CID').first()
+file_path = pyrfume.DATA_DIR / "cabinets" / "Mainland Odor Cabinet with CIDs.csv"
+df = pd.read_csv(file_path).reset_index().groupby("CID").first()
 
 
 ###### App layout ######
-dapp.layout = html.Div([
-    dcc.Graph(
-        id='odorants',
-        figure={
-            'data': [
-                go.Scatter(
-                    x=df[df['SourcedFrom'] == i]['Price'],
-                    y=df[df['SourcedFrom'] == i]['MW'],
-                    text=df[df['SourcedFrom'] == i]['ChemicalName'],
-                    mode='markers',
-                    opacity=0.7,
-                    marker={
-                        'size': 15,
-                        'line': {'width': 0.5, 'color': 'white'}
-                    },
-                    name=i
-                ) for i in df['SourcedFrom'].unique()
-            ],
-            'layout': go.Layout(
-                xaxis={'type': 'log', 'title': 'Price'},
-                yaxis={'type': 'log', 'title': 'Molecular Weight'},
-                margin={'l': 40, 'b': 40, 't': 10, 'r': 10},
-                legend={'x': 0, 'y': 1},
-                hovermode='closest'
-            )
-        }
-    )
-])
+dapp.layout = html.Div(
+    [
+        dcc.Graph(
+            id="odorants",
+            figure={
+                "data": [
+                    go.Scatter(
+                        x=df[df["SourcedFrom"] == i]["Price"],
+                        y=df[df["SourcedFrom"] == i]["MW"],
+                        text=df[df["SourcedFrom"] == i]["ChemicalName"],
+                        mode="markers",
+                        opacity=0.7,
+                        marker={"size": 15, "line": {"width": 0.5, "color": "white"}},
+                        name=i,
+                    )
+                    for i in df["SourcedFrom"].unique()
+                ],
+                "layout": go.Layout(
+                    xaxis={"type": "log", "title": "Price"},
+                    yaxis={"type": "log", "title": "Molecular Weight"},
+                    margin={"l": 40, "b": 40, "t": 10, "r": 10},
+                    legend={"x": 0, "y": 1},
+                    hovermode="closest",
+                ),
+            },
+        )
+    ]
+)
 
 
 ##### Run app #####
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=80)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/distance/app/main.py
+++ b/dash/distance/app/main.py
@@ -12,7 +12,7 @@ import pyrfume
 from pyrfume import haddad, snitz
 from pyrfume.odorants import smiles_to_image
 
-##### Initialize app #####
+### Initialize app ###
 
 bootstrap = "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 external_stylesheets = [bootstrap]
@@ -21,7 +21,7 @@ dapp = dash.Dash(
     __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
 )
 
-##### Load data #####
+### Load data ###
 
 # Pyrfume-data-relative file path
 file_path = "odorants/all_cids_properties.csv"
@@ -115,7 +115,7 @@ def show_histogram(space, distance):
     }
 
 
-###### App layout ######
+### App layout ###
 
 dapp.layout = html.Div(
     className="container-fluid",
@@ -161,7 +161,7 @@ dapp.layout = html.Div(
     + make_space_elements("haddad"),
 )
 
-##### App callbacks #####
+### App callbacks ###
 
 outputs = []
 for x in ("A", "B"):
@@ -216,7 +216,7 @@ def get_image_src(cid):
     return src
 
 
-##### Run app #####
+### Run app ###
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/distance/app/main.py
+++ b/dash/distance/app/main.py
@@ -13,160 +13,175 @@ from pyrfume import snitz, haddad
 
 ##### Initialize app #####
 
-bootstrap = 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css'
+bootstrap = "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 external_stylesheets = [bootstrap]
 app = flask.Flask(__name__)
-dapp = dash.Dash(__name__,
-                 server=app,
-                 url_base_pathname='/',
-                 external_stylesheets=external_stylesheets)
+dapp = dash.Dash(
+    __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
+)
 
 ##### Load data #####
 
 # Pyrfume-data-relative file path
-file_path = 'odorants/all_cids_properties.csv'
+file_path = "odorants/all_cids_properties.csv"
 # First 5 columns of all_cids file (name, MW, SMILES, etc.)
 details = pyrfume.load_data(file_path, usecols=range(5), index_col=0)
 # Dragon descriptor files with only the Snitz or Haddad features
 dragon = {}
-dragon['snitz'] = snitz.get_snitz_dragon().round(3)
-dragon['haddad'] = haddad.get_haddad_dragon().round(3)
+dragon["snitz"] = snitz.get_snitz_dragon().round(3)
+dragon["haddad"] = haddad.get_haddad_dragon().round(3)
 w = snitz.get_snitz_weights()
-dragon['snitz'].loc['Weight', w.index] = w
+dragon["snitz"].loc["Weight", w.index] = w
 w = haddad.get_haddad_weights()
-dragon['haddad'].loc['Weight', w.index] = w
+dragon["haddad"].loc["Weight", w.index] = w
 cumul = {}
-cumul['snitz'] = pyrfume.load_data('snitz_2013/snitz_cumulative_probability.csv')
-cumul['haddad'] = pyrfume.load_data('haddad_2008/haddad_cumulative_probability.csv')
+cumul["snitz"] = pyrfume.load_data("snitz_2013/snitz_cumulative_probability.csv")
+cumul["haddad"] = pyrfume.load_data("haddad_2008/haddad_cumulative_probability.csv")
 # Spaces to show
-spaces = OrderedDict({'snitz': 'Snitz Map',
-                      'haddad': 'Haddad Map'})
+spaces = OrderedDict({"snitz": "Snitz Map", "haddad": "Haddad Map"})
 
 
 def make_odorant_selector(name):
     """Make an Input widget to select an odorant by CID"""
     return dcc.Input(
-        id='cid_%s' % name,
-        placeholder='Enter a PubChem ID number...',
-        type='number',
+        id="cid_%s" % name,
+        placeholder="Enter a PubChem ID number...",
+        type="number",
         value=None,
-        )
+    )
 
 
 def make_space_table(space):
     """Make a data table for the given space"""
-    columns = dragon['%s' % space].reset_index().columns
-    return DataTable(id='%s_table' % space,
-                     columns=[{"name": i, "id": '%s' % i}
-                              for i in columns],
-                     data=get_table_data(space, []),
-                     style_header={'transform': 'translate(0px, 0px) rotate(-0.0deg)',
-                                   'max-width': '20px',
-                                   'backgroundColor': 'transparent'})
+    columns = dragon["%s" % space].reset_index().columns
+    return DataTable(
+        id="%s_table" % space,
+        columns=[{"name": i, "id": "%s" % i} for i in columns],
+        data=get_table_data(space, []),
+        style_header={
+            "transform": "translate(0px, 0px) rotate(-0.0deg)",
+            "max-width": "20px",
+            "backgroundColor": "transparent",
+        },
+    )
 
 
 def make_space_elements(space):
     """Return a list of elements to be used in a space layout"""
     return [
         html.Div(html.Hr()),
-        html.Div('%s' % space.title(),
-                 id='%s_title' % space,
-                 style={'font-size': '200%'}),
-        dcc.Graph(id='histogram_%s' % space,
-                  figure=show_histogram(space, 0)),
+        html.Div("%s" % space.title(), id="%s_title" % space, style={"font-size": "200%"}),
+        dcc.Graph(id="histogram_%s" % space, figure=show_histogram(space, 0)),
         make_space_table(space),
-        ]
+    ]
 
 
 def get_table_data(space, cids):
-    return dragon[space].loc[cids + ['Weight']].reset_index().to_dict('rows')
+    return dragon[space].loc[cids + ["Weight"]].reset_index().to_dict("rows")
 
 
 def get_distance(space, cids):
     a, b = cids
-    if space == 'snitz':
+    if space == "snitz":
         return snitz.get_snitz_distances(dragon[space]).loc[a, b]
-    if space == 'haddad':
+    if space == "haddad":
         return haddad.get_haddad_distances(dragon[space]).loc[a, b]
 
 
 def show_histogram(space, distance):
-    index = cumul[space].index.get_loc(distance, 'nearest')
+    index = cumul[space].index.get_loc(distance, "nearest")
     print(index)
-    cumul_prob = cumul[space].iloc[index]['Cumulative Probability']
+    cumul_prob = cumul[space].iloc[index]["Cumulative Probability"]
     return {
-        'data': [
-            go.Bar(**{
-                'x': cumul[space].index,
-                'y': cumul[space]['Cumulative Probability'],
-                'name': 'All pairs'
-                }),
-            go.Scatter(**{
-                'x': [distance],
-                'y': [cumul_prob],
-                'mode': 'markers',
-                'name': 'This pair'
-                })
-            ],
-
-        'layout': {
-            'title': '',
-            'width': 300,
-            'height': 100,
-            'margin': {'t': 10, 'b': 20},
-            },
-        }
+        "data": [
+            go.Bar(
+                **{
+                    "x": cumul[space].index,
+                    "y": cumul[space]["Cumulative Probability"],
+                    "name": "All pairs",
+                }
+            ),
+            go.Scatter(
+                **{"x": [distance], "y": [cumul_prob], "mode": "markers", "name": "This pair"}
+            ),
+        ],
+        "layout": {
+            "title": "",
+            "width": 300,
+            "height": 100,
+            "margin": {"t": 10, "b": 20},
+        },
+    }
 
 
 ###### App layout ######
 
-dapp.layout = html.Div(className='container-fluid', children=[
-    html.Div(className='row', children=[
-        html.Div(className='col',
-                 children=[html.Div("Molecule %s" % x)],
-                 style={'font-size': '200%'})
-        for x in ('A', 'B')]),
-    html.Div(className='row', children=[
-        html.Div(className='col',
-                 children=[make_odorant_selector(x)])
-        for x in ('A', 'B')]),
-
-    html.Div(className='row', children=[
-        html.Div(className='col', children=[
-            html.Table([
-                html.Tr([html.Td(['Name:']),
-                         html.Td(id='name_%s' % x)]),
-                html.Tr([html.Td(['SMILES:']),
-                         html.Td(id='smiles_%s' % x)]),
-                ], style={'vertical-align': 'middle',
-                          'font-size': '160%'}),
-            html.Img(id='molecule-2d_%s' % x, src=''), ])
-        for x in ('A', 'B')]),
-    ] + make_space_elements('snitz') + make_space_elements('haddad')
+dapp.layout = html.Div(
+    className="container-fluid",
+    children=[
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[html.Div("Molecule %s" % x)],
+                    style={"font-size": "200%"},
+                )
+                for x in ("A", "B")
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(className="col", children=[make_odorant_selector(x)]) for x in ("A", "B")
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        html.Table(
+                            [
+                                html.Tr([html.Td(["Name:"]), html.Td(id="name_%s" % x)]),
+                                html.Tr([html.Td(["SMILES:"]), html.Td(id="smiles_%s" % x)]),
+                            ],
+                            style={"vertical-align": "middle", "font-size": "160%"},
+                        ),
+                        html.Img(id="molecule-2d_%s" % x, src=""),
+                    ],
+                )
+                for x in ("A", "B")
+            ],
+        ),
+    ]
+    + make_space_elements("snitz")
+    + make_space_elements("haddad"),
 )
 
 ##### App callbacks #####
 
 outputs = []
-for x in ('A', 'B'):
-    outputs.append(Output('name_%s' % x, 'children'))
-    outputs.append(Output('smiles_%s' % x, 'children'))
-    outputs.append(Output('molecule-2d_%s' % x, 'src'))
+for x in ("A", "B"):
+    outputs.append(Output("name_%s" % x, "children"))
+    outputs.append(Output("smiles_%s" % x, "children"))
+    outputs.append(Output("molecule-2d_%s" % x, "src"))
 for space in spaces:
-    outputs.append(Output('%s_table' % space, 'data'))
-    outputs.append(Output('%s_title' % space, 'children'))
-    outputs.append(Output('histogram_%s' % space, 'figure'))
+    outputs.append(Output("%s_table" % space, "data"))
+    outputs.append(Output("%s_title" % space, "children"))
+    outputs.append(Output("histogram_%s" % space, "figure"))
 
 
 @dapp.callback(
     outputs,
-    [Input('cid_%s' % x, 'value') for x in ('A', 'B')],
-    )
+    [Input("cid_%s" % x, "value") for x in ("A", "B")],
+)
 def select_cid(*values):
     cids = OrderedDict()
-    for i, x in enumerate(['A', 'B']):
+    for i, x in enumerate(["A", "B"]):
         cids[x] = values[i]
-    result = ['']*12
+    result = [""] * 12
     show_cids = []
     for i, (x, cid) in enumerate(cids.items()):
         if cid is not None:
@@ -176,32 +191,31 @@ def select_cid(*values):
                 pass
             else:
                 show_cids.append(cid)
-                result[3*i] = name
-                result[3*i + 1] = smiles
-                result[3*i + 2] = get_image_src(cid)
+                result[3 * i] = name
+                result[3 * i + 1] = smiles
+                result[3 * i + 2] = get_image_src(cid)
     for i, space in enumerate(spaces):
-        result[6 + 3*i] = get_table_data(space, show_cids)
+        result[6 + 3 * i] = get_table_data(space, show_cids)
         if len(show_cids) == 2:
             distance = get_distance(space, show_cids)
-            result[7 + 3*i] = '%s: %.3g' % (space.title(),
-                                            distance)
-            result[8 + 3*i] = show_histogram(space, distance)
+            result[7 + 3 * i] = "%s: %.3g" % (space.title(), distance)
+            result[8 + 3 * i] = show_histogram(space, distance)
         else:
-            result[7 + 3*i] = '%s' % space.title()
-            result[8 + 3*i] = show_histogram(space, 0)
+            result[7 + 3 * i] = "%s" % space.title()
+            result[8 + 3 * i] = show_histogram(space, 0)
     return result
 
 
 def get_image_src(cid):
     if cid is None:
-        return ''
-    smiles = details.loc[cid, 'SMILES']
+        return ""
+    smiles = details.loc[cid, "SMILES"]
     image = smiles_to_image(smiles, png=True, b64=True, crop=True, size=250)
-    src = 'data:image/png;base64, %s' % image
+    src = "data:image/png;base64, %s" % image
     return src
 
 
 ##### Run app #####
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=80)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/distance/app/main.py
+++ b/dash/distance/app/main.py
@@ -1,15 +1,16 @@
 from collections import OrderedDict
-import dash
+
 import dash_core_components as dcc
 import dash_html_components as html
+import flask
+import plotly.graph_objs as go
 from dash.dependencies import Input, Output
 from dash_table import DataTable
-import plotly.graph_objs as go
-import flask
-import pyrfume
-from pyrfume.odorants import smiles_to_image
-from pyrfume import snitz, haddad
 
+import dash
+import pyrfume
+from pyrfume import haddad, snitz
+from pyrfume.odorants import smiles_to_image
 
 ##### Initialize app #####
 

--- a/dash/dream/app/main.py
+++ b/dash/dream/app/main.py
@@ -10,17 +10,17 @@ import pyrfume
 from pyrfume.odorants import smiles_to_image, from_cids, cids_to_smiles
 from pyrfume.predictions import load_dream_model, smiles_to_features, predict
 import pathlib
-OUTPUT_DIR = pathlib.Path(__file__).parent / 'data'
+
+OUTPUT_DIR = pathlib.Path(__file__).parent / "data"
 
 ##### Initialize app #####
 
-bootstrap = 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css'
+bootstrap = "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 external_stylesheets = [bootstrap]
 app = flask.Flask(__name__)
-dapp = dash.Dash(__name__,
-                 server=app,
-                 url_base_pathname='/',
-                 external_stylesheets=external_stylesheets)
+dapp = dash.Dash(
+    __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
+)
 
 ##### Load model #####
 
@@ -30,36 +30,37 @@ model, use_features, descriptors, imputer = load_dream_model()
 def make_odorant_selector():
     """Make an Input widget to select an odorant by CID"""
     return dcc.Input(
-        id='smiles',
-        placeholder='Input a SMILES string and press enter...',
-        type='text',
-        value='CCCCO',
+        id="smiles",
+        placeholder="Input a SMILES string and press enter...",
+        type="text",
+        value="CCCCO",
         debounce=True,
-        )
+    )
 
 
 def make_descriptors_table(data=None):
     """Make a data table for the given space"""
     if data is None:
         data = [{i: None for i in descriptors}]
-    return DataTable(id='model_output',
-                     columns=[{"name": 'SMILES', "id": 'smiles'}]+\
-                             [{"name": i, "id": i} for i in descriptors],
-                     data=data,
-                     style_header={'transform': 'translate(0px, 0px) rotate(-0.0deg)',
-                                   'max-width': '20px',
-                                   'backgroundColor': 'transparent'})
+    return DataTable(
+        id="model_output",
+        columns=[{"name": "SMILES", "id": "smiles"}] + [{"name": i, "id": i} for i in descriptors],
+        data=data,
+        style_header={
+            "transform": "translate(0px, 0px) rotate(-0.0deg)",
+            "max-width": "20px",
+            "backgroundColor": "transparent",
+        },
+    )
 
 
 def make_elements(data=None):
     """Return a list of elements to be used in a space layout"""
     return [
         html.Div(html.Hr()),
-        html.Div('Model Output',
-                 id='output_title',
-                 style={'font-size': '200%'}),
+        html.Div("Model Output", id="output_title", style={"font-size": "200%"}),
         make_descriptors_table(data),
-        ]
+    ]
 
 
 def get_model_output(smiles):
@@ -72,81 +73,86 @@ def get_model_output(smiles):
         smiles = [x[int(s)] if s.isnumeric() else s for s in smiles]
     features = smiles_to_features(smiles, use_features, imputer)
     predictions = predict(model, features, descriptors).reset_index()
-    predictions['smiles'] = smiles
+    predictions["smiles"] = smiles
     print(predictions.shape, predictions.mean(), len(descriptors))
     import os
+
     print(os.getcwd())
-    print(OUTPUT_DIR / 'dream.csv')
-    predictions.set_index('smiles').to_csv(OUTPUT_DIR / 'dream.csv')
+    print(OUTPUT_DIR / "dream.csv")
+    predictions.set_index("smiles").to_csv(OUTPUT_DIR / "dream.csv")
     return predictions
+
 
 ###### App layout ######
 
-dapp.layout = html.Div(className='container-fluid', children=[
-    html.Div(className='row', children=[
-        html.Div(className='col',
-                 children=[make_odorant_selector()])
-        ]),
+dapp.layout = html.Div(
+    className="container-fluid",
+    children=[
+        html.Div(
+            className="row",
+            children=[html.Div(className="col", children=[make_odorant_selector()])],
+        ),
+        # html.Div(className='row', children=[
+        #    html.Div(className='col', children=[
+        #        html.Table([
+        #            html.Tr([html.Td(['Name:']),
+        #                     html.Td(id='name')]),
+        #            ], style={'vertical-align': 'middle',
+        #                      'font-size': '160%'}),
+        #        html.Img(id='molecule-2d', src=''), ])
+        #    ]),
+        html.Div(
+            className="row",
+            children=[html.Div(className="col", children=[make_descriptors_table()])],
+        ),
+        html.Div(
+            className="row",
+            children=[html.Div(className="col", children=[html.A("Download", href="download")])],
+        ),
+    ],
+)
 
-    #html.Div(className='row', children=[
-    #    html.Div(className='col', children=[
-    #        html.Table([
-    #            html.Tr([html.Td(['Name:']),
-    #                     html.Td(id='name')]),
-    #            ], style={'vertical-align': 'middle',
-    #                      'font-size': '160%'}),
-    #        html.Img(id='molecule-2d', src=''), ])
-    #    ]),
 
-    html.Div(className='row', children=[
-        html.Div(className='col',
-                 children=[make_descriptors_table()])
-        ]),
-    
-    html.Div(className='row', children=[
-        html.Div(className='col',
-                 children=[html.A('Download', href='download')])
-        ]),
-])
-
-
-@dapp.server.route('/download') 
+@dapp.server.route("/download")
 def download_csv():
-    return send_file(OUTPUT_DIR / 'dream.csv',
-                     mimetype='text/csv',
-                     attachment_filename='dream.csv',
-                     as_attachment=True)
+    return send_file(
+        OUTPUT_DIR / "dream.csv",
+        mimetype="text/csv",
+        attachment_filename="dream.csv",
+        as_attachment=True,
+    )
+
 
 ##### App callbacks #####
 
 outputs = []
-#outputs.append(Output('name', 'children'))
-#outputs.append(Output('molecule-2d', 'src'))
-outputs.append(Output('model_output', 'data'))
+# outputs.append(Output('name', 'children'))
+# outputs.append(Output('molecule-2d', 'src'))
+outputs.append(Output("model_output", "data"))
 
 
 @dapp.callback(
     outputs,
-    [Input('smiles', 'value')],
-    )
+    [Input("smiles", "value")],
+)
 def select_cid(smiles):
-    smiles = smiles.split(',')
-    result = ['']*1
-    #result[0] = 'Something'
-    #result[1] = get_image_src(smiles[0])
-    result[0] = get_model_output(smiles).to_dict('records')
+    smiles = smiles.split(",")
+    result = [""] * 1
+    # result[0] = 'Something'
+    # result[1] = get_image_src(smiles[0])
+    result[0] = get_model_output(smiles).to_dict("records")
     return result
 
 
 def get_image_src(smiles):
     if not smiles:
-        return ''
+        return ""
     image = smiles_to_image(smiles, png=True, b64=True, crop=True, size=250)
-    src = 'data:image/png;base64, %s' % image
+    src = "data:image/png;base64, %s" % image
     return src
 
 
 ##### Run app #####
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=8000)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True, port=8000)

--- a/dash/dream/app/main.py
+++ b/dash/dream/app/main.py
@@ -3,19 +3,17 @@ import pathlib
 import dash_core_components as dcc
 import dash_html_components as html
 import flask
-import numpy as np
 from dash.dependencies import Input, Output
 from dash_table import DataTable
 from flask import send_file
 
 import dash
-import pyrfume
-from pyrfume.odorants import cids_to_smiles, from_cids, smiles_to_image
+from pyrfume.odorants import cids_to_smiles, smiles_to_image
 from pyrfume.predictions import load_dream_model, predict, smiles_to_features
 
 OUTPUT_DIR = pathlib.Path(__file__).parent / "data"
 
-##### Initialize app #####
+### Initialize app ###
 
 bootstrap = "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 external_stylesheets = [bootstrap]
@@ -24,7 +22,7 @@ dapp = dash.Dash(
     __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
 )
 
-##### Load model #####
+### Load model ###
 
 model, use_features, descriptors, imputer = load_dream_model()
 
@@ -85,7 +83,7 @@ def get_model_output(smiles):
     return predictions
 
 
-###### App layout ######
+### App layout ###
 
 dapp.layout = html.Div(
     className="container-fluid",
@@ -125,7 +123,7 @@ def download_csv():
     )
 
 
-##### App callbacks #####
+### App callbacks ###
 
 outputs = []
 # outputs.append(Output('name', 'children'))
@@ -154,7 +152,7 @@ def get_image_src(smiles):
     return src
 
 
-##### Run app #####
+### Run app ###
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=True, port=8000)

--- a/dash/dream/app/main.py
+++ b/dash/dream/app/main.py
@@ -1,15 +1,17 @@
-import dash
+import pathlib
+
 import dash_core_components as dcc
 import dash_html_components as html
+import flask
+import numpy as np
 from dash.dependencies import Input, Output
 from dash_table import DataTable
-import flask
 from flask import send_file
-import numpy as np
+
+import dash
 import pyrfume
-from pyrfume.odorants import smiles_to_image, from_cids, cids_to_smiles
-from pyrfume.predictions import load_dream_model, smiles_to_features, predict
-import pathlib
+from pyrfume.odorants import cids_to_smiles, from_cids, smiles_to_image
+from pyrfume.predictions import load_dream_model, predict, smiles_to_features
 
 OUTPUT_DIR = pathlib.Path(__file__).parent / "data"
 

--- a/dash/odorless/app/main.py
+++ b/dash/odorless/app/main.py
@@ -14,19 +14,19 @@ from pyrfume.odorants import smiles_to_image, all_odorants, all_sources
 
 
 ##### Initialize app #####
-external_stylesheets = ['https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css']
+external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]
 app = flask.Flask(__name__)
-dapp = dash.Dash(__name__,
-                 server=app,
-                 url_base_pathname='/',
-                 external_stylesheets=external_stylesheets)
+dapp = dash.Dash(
+    __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
+)
 
 ##### Load data #####
-pyrfume.set_data_path('data')
-gdb_umap = pyrfume.load_data('gdb_umap.pkl', remote=False)
-pf_umap = pyrfume.load_data('pf_umap.pkl', remote=False)
+pyrfume.set_data_path("data")
+gdb_umap = pyrfume.load_data("gdb_umap.pkl", remote=False)
+pf_umap = pyrfume.load_data("pf_umap.pkl", remote=False)
 
-hover_on = 1  
+hover_on = 1
+
 
 def plot(big_umap, known_umap, skip=10):
     big_umap = big_umap.iloc[::skip]
@@ -36,16 +36,16 @@ def plot(big_umap, known_umap, skip=10):
     big_scatter = go.Scatter(
         x=big_umap.loc[:, 0],
         y=big_umap.loc[:, 1],
-        name='Possible Molecules',
+        name="Possible Molecules",
         mode="markers",
         hoverinfo="text",
         opacity=0.5,
         marker={
             "size": 5,
             "line": {"width": 0.5, "color": "white"},
-            "color": big_umap.loc[:, 'p'],
-            "colorscale": 'magma',
-            "colorbar": {'thickness': 20, 'title': 'p(Odorous)'},
+            "color": big_umap.loc[:, "p"],
+            "colorscale": "magma",
+            "colorbar": {"thickness": 20, "title": "p(Odorous)"},
         },
     )
 
@@ -53,7 +53,7 @@ def plot(big_umap, known_umap, skip=10):
     known_scatter = go.Scattergl(
         x=known_umap.loc[:, 0],
         y=known_umap.loc[:, 1],
-        name='Known Odorous',
+        name="Known Odorous",
         mode="markers",
         hoverinfo="text",
         opacity=1,
@@ -69,7 +69,7 @@ def plot(big_umap, known_umap, skip=10):
         xaxis={"type": "linear", "title": "", "showline": False, "showticklabels": False},
         yaxis={"type": "linear", "title": "", "showline": False, "showticklabels": False},
         margin={"l": 40, "b": 40, "t": 10, "r": 10},
-        legend={"x": 0, "y": 1, 'font':{'size':15, 'color': 'white'}},
+        legend={"x": 0, "y": 1, "font": {"size": 15, "color": "white"}},
         hovermode="closest",
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(10,10,10,1)",
@@ -78,32 +78,32 @@ def plot(big_umap, known_umap, skip=10):
         xaxis_showgrid=False,
         yaxis_showgrid=False,
         xaxis_zeroline=False,
-        yaxis_zeroline=False
+        yaxis_zeroline=False,
     )
 
     fig = go.FigureWidget(data=[big_scatter, known_scatter], layout=layout)
-    fig.layout.hovermode = 'closest'
+    fig.layout.hovermode = "closest"
 
     # The 2D drawing of the molecule
     first_smiles = "CCCCO"
     image_widget = Image(
         value=smiles_to_image(first_smiles),
-        layout=Layout(height="200px", width="200px", left='50px', top='-250px')
-        )
-    
+        layout=Layout(height="200px", width="200px", left="50px", top="-250px"),
+    )
+
     text_widget = Text(
         value=first_smiles,
         placeholder=first_smiles,
-        description='SMILES:',
+        description="SMILES:",
         disabled=False,
-        layout=Layout(width='400px', left='25px', top='-285px')
+        layout=Layout(width="400px", left="25px", top="-285px"),
     )
 
     def hover_fn(trace, points, state):
-        #print(points)
+        # print(points)
         try:
             ind = points.point_inds[0]
-            if trace.name == 'Possible Molecules':
+            if trace.name == "Possible Molecules":
                 use = big_umap
             else:
                 use = known_umap
@@ -114,7 +114,7 @@ def plot(big_umap, known_umap, skip=10):
             pass
         except Exception as e:
             print(e)
-                  
+
     def click_fn(trace, points, state):
         global hover_on
         if hover_on:
@@ -123,27 +123,25 @@ def plot(big_umap, known_umap, skip=10):
         else:
             fig.data[0].on_hover(hover_fn)
             hover_on = 1
-            
+
     fig.data[0].on_hover(hover_fn)
     fig.data[0].on_click(click_fn)
-    canvas = GridBox([fig, image_widget, text_widget], layout={'gridgap': '0'})
+    canvas = GridBox([fig, image_widget, text_widget], layout={"gridgap": "0"})
     return canvas
 
-plot(gdb_umap, pf_umap, skip=10)
 
+plot(gdb_umap, pf_umap, skip=10)
 
 
 details = all_odorants()
 sources = all_sources()
 
-spaces = OrderedDict({'snitz': 'Snitz Map',
-                      'haddad': 'Haddad Map',
-                      'westeros': 'Westeros Map'})
-algorithm = 'umap'
+spaces = OrderedDict({"snitz": "Snitz Map", "haddad": "Haddad Map", "westeros": "Westeros Map"})
+algorithm = "umap"
 embeddings = {}
 for space in spaces:
-    key = '%s_%s' % (space, algorithm)
-    with open(pyrfume.DATA_DIR / 'odorants' / ('%s.pkl' % key), 'rb') as f:
+    key = "%s_%s" % (space, algorithm)
+    with open(pyrfume.DATA_DIR / "odorants" / ("%s.pkl" % key), "rb") as f:
         embeddings[space] = pickle.load(f)
         # Remove molecules for which there are no details
         good_cids = details.index.intersection(embeddings[space].index)
@@ -152,85 +150,107 @@ for space in spaces:
 # Assert that all embeddings have the same number of molecules
 assert len(set([embeddings[space].shape[0] for space in spaces])) == 1
 
+
 def make_figure(embedding, title):
     return {
-        'data': [
-            go.Scattergl(**{
-                'x': embedding.loc[:, 'X'].values,
-                'y': embedding.loc[:, 'Y'].values,
-                'mode': 'markers',
-                'marker': {'size': 5,
-                           'color': embedding.loc[:, 'cluster'].values,
-                           'opacity': 0.5,
-                           'cmax': 9,
-                           'cmin': 0,
-                           'colorscale': 'Rainbow'}
-                }),
-            ],
-
-        'layout': {
-            'title': title,
-            'clickmode': 'event',
-            'xaxis': {'type': 'linear',
-                      'title': '',
-                      'zeroline': False,
-                      'showgrid': False,
-                      'showline': False,
-                      'showticklabels': False},
-            'yaxis': {'type': 'linear',
-                      'title': '',
-                      'zeroline': False,
-                      'showgrid': False,
-                      'showline': False,
-                      'showticklabels': False},
-            'margin': {'l': 40, 'b': 40, 't': 10, 'r': 10},
-            'legend': {'x': 0, 'y': 1},
-            'hovermode': 'closest',
-            'paper_bgcolor': 'rgba(0,0,0,0)',
-            'plot_bgcolor': 'rgba(0,0,0,0)',
-            'width': 700,
-            'height': 500,
-            'margin': {'t': 50},
+        "data": [
+            go.Scattergl(
+                **{
+                    "x": embedding.loc[:, "X"].values,
+                    "y": embedding.loc[:, "Y"].values,
+                    "mode": "markers",
+                    "marker": {
+                        "size": 5,
+                        "color": embedding.loc[:, "cluster"].values,
+                        "opacity": 0.5,
+                        "cmax": 9,
+                        "cmin": 0,
+                        "colorscale": "Rainbow",
+                    },
+                }
+            ),
+        ],
+        "layout": {
+            "title": title,
+            "clickmode": "event",
+            "xaxis": {
+                "type": "linear",
+                "title": "",
+                "zeroline": False,
+                "showgrid": False,
+                "showline": False,
+                "showticklabels": False,
             },
-        }
+            "yaxis": {
+                "type": "linear",
+                "title": "",
+                "zeroline": False,
+                "showgrid": False,
+                "showline": False,
+                "showticklabels": False,
+            },
+            "margin": {"l": 40, "b": 40, "t": 10, "r": 10},
+            "legend": {"x": 0, "y": 1},
+            "hovermode": "closest",
+            "paper_bgcolor": "rgba(0,0,0,0)",
+            "plot_bgcolor": "rgba(0,0,0,0)",
+            "width": 700,
+            "height": 500,
+            "margin": {"t": 50},
+        },
+    }
 
 
 ###### App layout ######
-dapp.layout = html.Div(className='container-fluid', children=[ 
-    html.Div(className='row', children=[
-        html.Div(className='col', children=[
-            dcc.Graph(
-                id=space,
-                clear_on_unhover=True,
-                figure=make_figure(embeddings[space], title))
-                ])
-            for space, title in spaces.items()]),
-
-    html.Div(className='row', children=[
-        html.Div(className='col', children=[
-            html.Table([
-                html.Tr([html.Td(['CID:']),
-                         html.Td([html.A(id='cid',
-                                         href='#')])]),
-                html.Tr([html.Td(['MW:']),
-                         html.Td(id='mw')]),
-                html.Tr([html.Td(['Name:']),
-                         html.Td(id='name')]),
-                html.Tr([html.Td(['SMILES:']),
-                         html.Td(id='smiles')]),
-                html.Tr([html.Td(['IUPAC:']),
-                         html.Td(id='iupac')]),
-                html.Tr([html.Td(['Sources:']),
-                         html.Td(id='sources')]),
-                ], style={'vertical-align': 'middle',
-                          'font-size': '160%'})]),
-        html.Div(className='col', children=[
-            html.Img(id='molecule-2d', src=''),
-            ]),
-        ]),
-
-    html.Div(id='hidden-div', style={'display': 'none'})
-    ])
+dapp.layout = html.Div(
+    className="container-fluid",
+    children=[
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        dcc.Graph(
+                            id=space,
+                            clear_on_unhover=True,
+                            figure=make_figure(embeddings[space], title),
+                        )
+                    ],
+                )
+                for space, title in spaces.items()
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        html.Table(
+                            [
+                                html.Tr([html.Td(["CID:"]), html.Td([html.A(id="cid", href="#")])]),
+                                html.Tr([html.Td(["MW:"]), html.Td(id="mw")]),
+                                html.Tr([html.Td(["Name:"]), html.Td(id="name")]),
+                                html.Tr([html.Td(["SMILES:"]), html.Td(id="smiles")]),
+                                html.Tr([html.Td(["IUPAC:"]), html.Td(id="iupac")]),
+                                html.Tr([html.Td(["Sources:"]), html.Td(id="sources")]),
+                            ],
+                            style={"vertical-align": "middle", "font-size": "160%"},
+                        )
+                    ],
+                ),
+                html.Div(
+                    className="col",
+                    children=[
+                        html.Img(id="molecule-2d", src=""),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(id="hidden-div", style={"display": "none"}),
+    ],
+)
 
 # multiple callback error suppressed [Div has no .keys() atrribute]
 # dapp.config['suppress_callback_exceptions']=True
@@ -240,23 +260,24 @@ def get_index(*hoverData):
     index = None
     for hoverDatum in hoverData:
         if hoverDatum:
-            index = hoverDatum['points'][0]['pointIndex']
+            index = hoverDatum["points"][0]["pointIndex"]
     return index
 
 
 ##### App callbacks #####
 @dapp.callback(
-    [Output('cid', 'children'),
-     Output('cid', 'href'),
-     Output('mw', 'children'),
-     Output('name', 'children'),
-     Output('smiles', 'children'),
-     Output('iupac', 'children'),
-     Output('sources', 'children'),
-     Output('molecule-2d', 'src'),
-     ],
-    [Input(space, 'hoverData') for space in spaces],
-     )
+    [
+        Output("cid", "children"),
+        Output("cid", "href"),
+        Output("mw", "children"),
+        Output("name", "children"),
+        Output("smiles", "children"),
+        Output("iupac", "children"),
+        Output("sources", "children"),
+        Output("molecule-2d", "src"),
+    ],
+    [Input(space, "hoverData") for space in spaces],
+)
 def _display_hover(*hoverData):
     index = get_index(*hoverData)
     if index is not None:
@@ -265,27 +286,27 @@ def _display_hover(*hoverData):
 
 
 def display_hover(index):
-    columns = ['CID', 'MW', 'Name', 'SMILES', 'IUPACName']
+    columns = ["CID", "MW", "Name", "SMILES", "IUPACName"]
     if index is None:
-        return ['']*8
+        return [""] * 8
     info = details.reset_index().iloc[index][columns]
     cid, mw, name, smiles, iupacname = info.values
-    cid_url = 'https://pubchem.ncbi.nlm.nih.gov/compound/%d' % cid
+    cid_url = "https://pubchem.ncbi.nlm.nih.gov/compound/%d" % cid
     source = sources.reset_index().loc[index]
-    source = ', '.join(source[source == 1].index)
+    source = ", ".join(source[source == 1].index)
     hover_image_src = display_hover_image(index)
     return [cid, cid_url, mw, name, smiles, iupacname, source, hover_image_src]
 
 
 def display_hover_image(index):
     if index is None:
-        return ''
-    smiles = details.iloc[index]['SMILES']
+        return ""
+    smiles = details.iloc[index]["SMILES"]
     image = smiles_to_image(smiles, png=True, b64=True, crop=True, size=500)
-    src = 'data:image/png;base64, %s' % image
+    src = "data:image/png;base64, %s" % image
     return src
 
 
 ##### Run app #####
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=80)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/odorless/app/main.py
+++ b/dash/odorless/app/main.py
@@ -1,17 +1,18 @@
+import pickle
 from collections import OrderedDict
-import dash
+
 import dash_core_components as dcc
 import dash_html_components as html
-from dash.dependencies import Input, Output, State
-from ipywidgets import Text, Image, Layout, GridBox
-import plotly.graph_objs as go
 import flask
 import numpy as np
 import pandas as pd
-import pickle
-import pyrfume
-from pyrfume.odorants import smiles_to_image, all_odorants, all_sources
+import plotly.graph_objs as go
+from dash.dependencies import Input, Output, State
+from ipywidgets import GridBox, Image, Layout, Text
 
+import dash
+import pyrfume
+from pyrfume.odorants import all_odorants, all_sources, smiles_to_image
 
 ##### Initialize app #####
 external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]

--- a/dash/odorless/app/main.py
+++ b/dash/odorless/app/main.py
@@ -4,24 +4,22 @@ from collections import OrderedDict
 import dash_core_components as dcc
 import dash_html_components as html
 import flask
-import numpy as np
-import pandas as pd
 import plotly.graph_objs as go
-from dash.dependencies import Input, Output, State
+from dash.dependencies import Input, Output
 from ipywidgets import GridBox, Image, Layout, Text
 
 import dash
 import pyrfume
 from pyrfume.odorants import all_odorants, all_sources, smiles_to_image
 
-##### Initialize app #####
+### Initialize app ###
 external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]
 app = flask.Flask(__name__)
 dapp = dash.Dash(
     __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
 )
 
-##### Load data #####
+### Load data ###
 pyrfume.set_data_path("data")
 gdb_umap = pyrfume.load_data("gdb_umap.pkl", remote=False)
 pf_umap = pyrfume.load_data("pf_umap.pkl", remote=False)
@@ -190,19 +188,18 @@ def make_figure(embedding, title):
                 "showline": False,
                 "showticklabels": False,
             },
-            "margin": {"l": 40, "b": 40, "t": 10, "r": 10},
+            "margin": {"l": 40, "b": 40, "t": 50, "r": 10},
             "legend": {"x": 0, "y": 1},
             "hovermode": "closest",
             "paper_bgcolor": "rgba(0,0,0,0)",
             "plot_bgcolor": "rgba(0,0,0,0)",
             "width": 700,
             "height": 500,
-            "margin": {"t": 50},
         },
     }
 
 
-###### App layout ######
+### App layout ###
 dapp.layout = html.Div(
     className="container-fluid",
     children=[
@@ -265,7 +262,7 @@ def get_index(*hoverData):
     return index
 
 
-##### App callbacks #####
+### App callbacks ###
 @dapp.callback(
     [
         Output("cid", "children"),
@@ -308,6 +305,6 @@ def display_hover_image(index):
     return src
 
 
-##### Run app #####
+### Run app ###
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/odormap/app/main.py
+++ b/dash/odormap/app/main.py
@@ -1,16 +1,17 @@
+import pickle
 from collections import OrderedDict
-import dash
+
 import dash_core_components as dcc
 import dash_html_components as html
-from dash.dependencies import Input, Output, State
-import plotly.graph_objs as go
 import flask
 import numpy as np
 import pandas as pd
-import pickle
-import pyrfume
-from pyrfume.odorants import smiles_to_image, all_odorants, all_sources
+import plotly.graph_objs as go
+from dash.dependencies import Input, Output, State
 
+import dash
+import pyrfume
+from pyrfume.odorants import all_odorants, all_sources, smiles_to_image
 
 ##### Initialize app #####
 external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]

--- a/dash/odormap/app/main.py
+++ b/dash/odormap/app/main.py
@@ -13,25 +13,22 @@ from pyrfume.odorants import smiles_to_image, all_odorants, all_sources
 
 
 ##### Initialize app #####
-external_stylesheets = ['https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css']
+external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]
 app = flask.Flask(__name__)
-dapp = dash.Dash(__name__,
-                 server=app,
-                 url_base_pathname='/',
-                 external_stylesheets=external_stylesheets)
+dapp = dash.Dash(
+    __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
+)
 
 ##### Load data #####
 details = all_odorants()
 sources = all_sources()
 
-spaces = OrderedDict({'snitz': 'Snitz Map',
-                      'haddad': 'Haddad Map',
-                      'westeros': 'Westeros Map'})
-algorithm = 'umap'
+spaces = OrderedDict({"snitz": "Snitz Map", "haddad": "Haddad Map", "westeros": "Westeros Map"})
+algorithm = "umap"
 embeddings = {}
 for space in spaces:
-    key = '%s_%s' % (space, algorithm)
-    with open(pyrfume.DATA_DIR / 'odorants' / ('%s.pkl' % key), 'rb') as f:
+    key = "%s_%s" % (space, algorithm)
+    with open(pyrfume.DATA_DIR / "odorants" / ("%s.pkl" % key), "rb") as f:
         embeddings[space] = pickle.load(f)
         # Remove molecules for which there are no details
         good_cids = details.index.intersection(embeddings[space].index)
@@ -40,85 +37,107 @@ for space in spaces:
 # Assert that all embeddings have the same number of molecules
 assert len(set([embeddings[space].shape[0] for space in spaces])) == 1
 
+
 def make_figure(embedding, title):
     return {
-        'data': [
-            go.Scattergl(**{
-                'x': embedding.loc[:, 'X'].values,
-                'y': embedding.loc[:, 'Y'].values,
-                'mode': 'markers',
-                'marker': {'size': 5,
-                           'color': embedding.loc[:, 'cluster'].values,
-                           'opacity': 0.5,
-                           'cmax': 9,
-                           'cmin': 0,
-                           'colorscale': 'Rainbow'}
-                }),
-            ],
-
-        'layout': {
-            'title': title,
-            'clickmode': 'event',
-            'xaxis': {'type': 'linear',
-                      'title': '',
-                      'zeroline': False,
-                      'showgrid': False,
-                      'showline': False,
-                      'showticklabels': False},
-            'yaxis': {'type': 'linear',
-                      'title': '',
-                      'zeroline': False,
-                      'showgrid': False,
-                      'showline': False,
-                      'showticklabels': False},
-            'margin': {'l': 40, 'b': 40, 't': 10, 'r': 10},
-            'legend': {'x': 0, 'y': 1},
-            'hovermode': 'closest',
-            'paper_bgcolor': 'rgba(0,0,0,0)',
-            'plot_bgcolor': 'rgba(0,0,0,0)',
-            'width': 700,
-            'height': 500,
-            'margin': {'t': 50},
+        "data": [
+            go.Scattergl(
+                **{
+                    "x": embedding.loc[:, "X"].values,
+                    "y": embedding.loc[:, "Y"].values,
+                    "mode": "markers",
+                    "marker": {
+                        "size": 5,
+                        "color": embedding.loc[:, "cluster"].values,
+                        "opacity": 0.5,
+                        "cmax": 9,
+                        "cmin": 0,
+                        "colorscale": "Rainbow",
+                    },
+                }
+            ),
+        ],
+        "layout": {
+            "title": title,
+            "clickmode": "event",
+            "xaxis": {
+                "type": "linear",
+                "title": "",
+                "zeroline": False,
+                "showgrid": False,
+                "showline": False,
+                "showticklabels": False,
             },
-        }
+            "yaxis": {
+                "type": "linear",
+                "title": "",
+                "zeroline": False,
+                "showgrid": False,
+                "showline": False,
+                "showticklabels": False,
+            },
+            "margin": {"l": 40, "b": 40, "t": 10, "r": 10},
+            "legend": {"x": 0, "y": 1},
+            "hovermode": "closest",
+            "paper_bgcolor": "rgba(0,0,0,0)",
+            "plot_bgcolor": "rgba(0,0,0,0)",
+            "width": 700,
+            "height": 500,
+            "margin": {"t": 50},
+        },
+    }
 
 
 ###### App layout ######
-dapp.layout = html.Div(className='container-fluid', children=[ 
-    html.Div(className='row', children=[
-        html.Div(className='col', children=[
-            dcc.Graph(
-                id=space,
-                clear_on_unhover=True,
-                figure=make_figure(embeddings[space], title))
-                ])
-            for space, title in spaces.items()]),
-
-    html.Div(className='row', children=[
-        html.Div(className='col', children=[
-            html.Table([
-                html.Tr([html.Td(['CID:']),
-                         html.Td([html.A(id='cid',
-                                         href='#')])]),
-                html.Tr([html.Td(['MW:']),
-                         html.Td(id='mw')]),
-                html.Tr([html.Td(['Name:']),
-                         html.Td(id='name')]),
-                html.Tr([html.Td(['SMILES:']),
-                         html.Td(id='smiles')]),
-                html.Tr([html.Td(['IUPAC:']),
-                         html.Td(id='iupac')]),
-                html.Tr([html.Td(['Sources:']),
-                         html.Td(id='sources')]),
-                ], style={'vertical-align': 'middle',
-                          'font-size': '160%'})]),
-        html.Div(className='col', children=[
-            html.Img(id='molecule-2d', src=''),
-            ]),
-        ]),
-
-    html.Div(id='hidden-div', style={'display': 'none'})
-    ])
+dapp.layout = html.Div(
+    className="container-fluid",
+    children=[
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        dcc.Graph(
+                            id=space,
+                            clear_on_unhover=True,
+                            figure=make_figure(embeddings[space], title),
+                        )
+                    ],
+                )
+                for space, title in spaces.items()
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        html.Table(
+                            [
+                                html.Tr([html.Td(["CID:"]), html.Td([html.A(id="cid", href="#")])]),
+                                html.Tr([html.Td(["MW:"]), html.Td(id="mw")]),
+                                html.Tr([html.Td(["Name:"]), html.Td(id="name")]),
+                                html.Tr([html.Td(["SMILES:"]), html.Td(id="smiles")]),
+                                html.Tr([html.Td(["IUPAC:"]), html.Td(id="iupac")]),
+                                html.Tr([html.Td(["Sources:"]), html.Td(id="sources")]),
+                            ],
+                            style={"vertical-align": "middle", "font-size": "160%"},
+                        )
+                    ],
+                ),
+                html.Div(
+                    className="col",
+                    children=[
+                        html.Img(id="molecule-2d", src=""),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(id="hidden-div", style={"display": "none"}),
+    ],
+)
 
 # multiple callback error suppressed [Div has no .keys() atrribute]
 # dapp.config['suppress_callback_exceptions']=True
@@ -128,23 +147,24 @@ def get_index(*hoverData):
     index = None
     for hoverDatum in hoverData:
         if hoverDatum:
-            index = hoverDatum['points'][0]['pointIndex']
+            index = hoverDatum["points"][0]["pointIndex"]
     return index
 
 
 ##### App callbacks #####
 @dapp.callback(
-    [Output('cid', 'children'),
-     Output('cid', 'href'),
-     Output('mw', 'children'),
-     Output('name', 'children'),
-     Output('smiles', 'children'),
-     Output('iupac', 'children'),
-     Output('sources', 'children'),
-     Output('molecule-2d', 'src'),
-     ],
-    [Input(space, 'hoverData') for space in spaces],
-     )
+    [
+        Output("cid", "children"),
+        Output("cid", "href"),
+        Output("mw", "children"),
+        Output("name", "children"),
+        Output("smiles", "children"),
+        Output("iupac", "children"),
+        Output("sources", "children"),
+        Output("molecule-2d", "src"),
+    ],
+    [Input(space, "hoverData") for space in spaces],
+)
 def _display_hover(*hoverData):
     index = get_index(*hoverData)
     if index is not None:
@@ -153,27 +173,27 @@ def _display_hover(*hoverData):
 
 
 def display_hover(index):
-    columns = ['CID', 'MW', 'Name', 'SMILES', 'IUPACName']
+    columns = ["CID", "MW", "Name", "SMILES", "IUPACName"]
     if index is None:
-        return ['']*8
+        return [""] * 8
     info = details.reset_index().iloc[index][columns]
     cid, mw, name, smiles, iupacname = info.values
-    cid_url = 'https://pubchem.ncbi.nlm.nih.gov/compound/%d' % cid
+    cid_url = "https://pubchem.ncbi.nlm.nih.gov/compound/%d" % cid
     source = sources.reset_index().loc[index]
-    source = ', '.join(source[source == 1].index)
+    source = ", ".join(source[source == 1].index)
     hover_image_src = display_hover_image(index)
     return [cid, cid_url, mw, name, smiles, iupacname, source, hover_image_src]
 
 
 def display_hover_image(index):
     if index is None:
-        return ''
-    smiles = details.iloc[index]['SMILES']
+        return ""
+    smiles = details.iloc[index]["SMILES"]
     image = smiles_to_image(smiles, png=True, b64=True, crop=True, size=500)
-    src = 'data:image/png;base64, %s' % image
+    src = "data:image/png;base64, %s" % image
     return src
 
 
 ##### Run app #####
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=80)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", debug=True, port=80)

--- a/dash/odormap/app/main.py
+++ b/dash/odormap/app/main.py
@@ -4,23 +4,21 @@ from collections import OrderedDict
 import dash_core_components as dcc
 import dash_html_components as html
 import flask
-import numpy as np
-import pandas as pd
 import plotly.graph_objs as go
-from dash.dependencies import Input, Output, State
+from dash.dependencies import Input, Output
 
 import dash
 import pyrfume
 from pyrfume.odorants import all_odorants, all_sources, smiles_to_image
 
-##### Initialize app #####
+### Initialize app ###
 external_stylesheets = ["https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"]
 app = flask.Flask(__name__)
 dapp = dash.Dash(
     __name__, server=app, url_base_pathname="/", external_stylesheets=external_stylesheets
 )
 
-##### Load data #####
+### Load data ###
 details = all_odorants()
 sources = all_sources()
 
@@ -77,19 +75,18 @@ def make_figure(embedding, title):
                 "showline": False,
                 "showticklabels": False,
             },
-            "margin": {"l": 40, "b": 40, "t": 10, "r": 10},
+            "margin": {"l": 40, "b": 40, "t": 50, "r": 10},
             "legend": {"x": 0, "y": 1},
             "hovermode": "closest",
             "paper_bgcolor": "rgba(0,0,0,0)",
             "plot_bgcolor": "rgba(0,0,0,0)",
             "width": 700,
             "height": 500,
-            "margin": {"t": 50},
         },
     }
 
 
-###### App layout ######
+### App layout ###
 dapp.layout = html.Div(
     className="container-fluid",
     children=[
@@ -152,7 +149,7 @@ def get_index(*hoverData):
     return index
 
 
-##### App callbacks #####
+### App callbacks ###
 @dapp.callback(
     [
         Output("cid", "children"),
@@ -195,6 +192,6 @@ def display_hover_image(index):
     return src
 
 
-##### Run app #####
+### Run app ###
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=True, port=80)

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -3,7 +3,7 @@ ARG os_release="bullseye"
 
 
 FROM python:$python_version_base-$os_release
-ARG poetry_version="1.2.0b3"
+ARG poetry_version="1.2.0"
 ARG project="pyrfume"
 ARG username="$project"
 ARG workdir="/workspace/$project"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -15,7 +15,10 @@ RUN apt-get update --yes && \
     apt-get install --yes --no-install-recommends sudo && \
     apt-get clean && \
     useradd --user-group --create-home --groups users "$username" && \
-    echo "$username ALL=(ALL:ALL) NOPASSWD: ALL" | tee "/etc/sudoers.d/$username"
+    echo "$username ALL=(ALL:ALL) NOPASSWD: ALL" | tee "/etc/sudoers.d/$username" && \
+    parent_dir=$(dirname "$workdir") && \
+    mkdir "$parent_dir" && \
+    chown -R "$username" "$parent_dir"
 
 USER "$username"
 WORKDIR "$workdir"

--- a/docs/rtfd/conf.py
+++ b/docs/rtfd/conf.py
@@ -1,18 +1,20 @@
 """Configuration file for the Sphinx documentation builder."""
 
-project = 'Pyrfume'
-copyright = '2019-, Rick Gerkin and Joel Mainland'
-author = 'Rick Gerkin'
-version = '0.1'
-release = '0.1 alpha'
-extensions = ['sphinxcontrib.apidoc',
-              'sphinx.ext.intersphinx',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.githubpages']
-apidoc_module_dir = '../pyrfume'
-apidoc_output_dir = 'build'
-apidoc_excluded_paths = ['*unit_test*']
+project = "Pyrfume"
+copyright = "2019-, Rick Gerkin and Joel Mainland"
+author = "Rick Gerkin"
+version = "0.1"
+release = "0.1 alpha"
+extensions = [
+    "sphinxcontrib.apidoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+]
+apidoc_module_dir = "../pyrfume"
+apidoc_output_dir = "build"
+apidoc_excluded_paths = ["*unit_test*"]
 apidoc_separate_modules = True
-master_doc = 'index'
-exclude_patterns = ['*unit_test*']
-html_theme = 'alabaster'
+master_doc = "index"
+exclude_patterns = ["*unit_test*"]
+html_theme = "alabaster"

--- a/notebooks/GRAS.py
+++ b/notebooks/GRAS.py
@@ -18,13 +18,13 @@ import pandas as pd
 import pyrfume
 from pyrfume import odorants
 
-file_path = os.path.join(pyrfume.DATA, 'GRAS.smi')
-gras_data_raw = pd.read_csv(file_path, header=None, names=['SMILES', 'CAS'], sep='\t')
+file_path = os.path.join(pyrfume.DATA, "GRAS.smi")
+gras_data_raw = pd.read_csv(file_path, header=None, names=["SMILES", "CAS"], sep="\t")
 
-results = odorants.get_cids(gras_data_raw['SMILES'], kind='SMILES', verbose=False)
+results = odorants.get_cids(gras_data_raw["SMILES"], kind="SMILES", verbose=False)
 
-gras_data = pd.Series(results, name='CID').to_frame().join(gras_data_raw.set_index('SMILES'))
+gras_data = pd.Series(results, name="CID").to_frame().join(gras_data_raw.set_index("SMILES"))
 gras_data.head()
 
-file_path = os.path.join(pyrfume.DATA, 'gras.csv')
+file_path = os.path.join(pyrfume.DATA, "gras.csv")
 gras_data.to_csv(file_path)

--- a/notebooks/GRAS.py
+++ b/notebooks/GRAS.py
@@ -14,7 +14,9 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
 from pyrfume import odorants
 

--- a/notebooks/Generate SDF File.py
+++ b/notebooks/Generate SDF File.py
@@ -18,7 +18,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem, SaltRemover, rdmolfiles
 from mordred import Calculator, descriptors as all_descriptors
 
-smiles = pd.read_csv('data/cids-names-smiles.csv').set_index('CID')['IsomericSMILES']
+smiles = pd.read_csv("data/cids-names-smiles.csv").set_index("CID")["IsomericSMILES"]
 
 calc = Calculator(all_descriptors)
 print("Convering SMILES string to Mol format...")
@@ -29,26 +29,24 @@ for i, (cid, mol) in enumerate(mols.items()):
     if i > 0 and i % 100 == 0:
         print("Finished %d" % i)
     try:
-        mol.SetProp("_Name","%d: %s" % (cid, smiles[cid]))
-        mol = s.StripMol(mol,dontRemoveEverything=True)
+        mol.SetProp("_Name", "%d: %s" % (cid, smiles[cid]))
+        mol = s.StripMol(mol, dontRemoveEverything=True)
         mol = Chem.AddHs(mol)
         AllChem.Compute2DCoords(mol)
         AllChem.EmbedMolecule(mol)
-        AllChem.UFFOptimizeMolecule(mol) # Is this deterministic?  
+        AllChem.UFFOptimizeMolecule(mol)  # Is this deterministic?
     except Exception as e:
-        print('Exception for %d' % cid)
+        print("Exception for %d" % cid)
         mols[cid] = None
     else:
         mols[cid] = mol
 mols = {cid: mol for cid, mol in mols.items() if mol}
 
-writer = rdmolfiles.SDWriter('data/cids-smiles.sdf')
+writer = rdmolfiles.SDWriter("data/cids-smiles.sdf")
 for smile, mol in mols.items():
     writer.write(mol)
 writer.close()
 
-suppl = rdmolfiles.SDMolSupplier('data/cids-smiles.sdf')
+suppl = rdmolfiles.SDMolSupplier("data/cids-smiles.sdf")
 for mol in suppl:
     print(mol.GetNumAtoms())
-
-

--- a/notebooks/Generate SDF File.py
+++ b/notebooks/Generate SDF File.py
@@ -14,9 +14,10 @@
 # ---
 
 import pandas as pd
+from mordred import Calculator
+from mordred import descriptors as all_descriptors
 from rdkit import Chem
 from rdkit.Chem import AllChem, SaltRemover, rdmolfiles
-from mordred import Calculator, descriptors as all_descriptors
 
 smiles = pd.read_csv("data/cids-names-smiles.csv").set_index("CID")["IsomericSMILES"]
 

--- a/notebooks/Generate SDF File.py
+++ b/notebooks/Generate SDF File.py
@@ -36,7 +36,7 @@ for i, (cid, mol) in enumerate(mols.items()):
         AllChem.Compute2DCoords(mol)
         AllChem.EmbedMolecule(mol)
         AllChem.UFFOptimizeMolecule(mol)  # Is this deterministic?
-    except Exception as e:
+    except Exception:
         print("Exception for %d" % cid)
         mols[cid] = None
     else:

--- a/notebooks/Intensity-Mordred.py
+++ b/notebooks/Intensity-Mordred.py
@@ -12,5 +12,3 @@
 #     language: python
 #     name: python3
 # ---
-
-

--- a/notebooks/Leffingwell.py
+++ b/notebooks/Leffingwell.py
@@ -19,33 +19,37 @@ import pyrfume
 from pyrfume import odorants
 from rdkit import Chem
 
-file_path = os.path.join(pyrfume.DATA, 'westeros', 'molecules.csv')
-leffingwell_data_raw = pd.read_csv(file_path, sep='\t')
+file_path = os.path.join(pyrfume.DATA, "westeros", "molecules.csv")
+leffingwell_data_raw = pd.read_csv(file_path, sep="\t")
 
-results = odorants.get_cids(leffingwell_data_raw['smiles'], kind='SMILES', verbose=False)
+results = odorants.get_cids(leffingwell_data_raw["smiles"], kind="SMILES", verbose=False)
 
-leffingwell_data = pd.Series(results, name='CID').to_frame().join(leffingwell_data_raw.set_index('smiles'))
+leffingwell_data = (
+    pd.Series(results, name="CID").to_frame().join(leffingwell_data_raw.set_index("smiles"))
+)
 leffingwell_data.head()
 
-for smiles in leffingwell_data[leffingwell_data['CID']==0].index:
-    name = leffingwell_data.loc[smiles, 'chemical_name']
+for smiles in leffingwell_data[leffingwell_data["CID"] == 0].index:
+    name = leffingwell_data.loc[smiles, "chemical_name"]
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         print("Bad smiles: %s" % smiles)
     else:
         smiles = Chem.MolToSmiles(mol, isomericSmiles=True)
-    cid = odorants.get_cid(smiles, kind='smiles', verbose=True)
+    cid = odorants.get_cid(smiles, kind="smiles", verbose=True)
     if cid:
         print(name, cid)
     else:
         print(name, smiles)
 
-leffingwell_data = pd.Series(results, name='CID').to_frame().join(leffingwell_data_raw.set_index('smiles'))
-leffingwell_data[leffingwell_data['CID']==0]
+leffingwell_data = (
+    pd.Series(results, name="CID").to_frame().join(leffingwell_data_raw.set_index("smiles"))
+)
+leffingwell_data[leffingwell_data["CID"] == 0]
 
-x = leffingwell_data.reset_index().set_index('chemical_name')
-#x.loc['calcium alginate', 0]
-x[x['CID']==0].head()
+x = leffingwell_data.reset_index().set_index("chemical_name")
+# x.loc['calcium alginate', 0]
+x[x["CID"] == 0].head()
 
-file_path = os.path.join(pyrfume.DATA, 'westeros', 'westeros.csv')
+file_path = os.path.join(pyrfume.DATA, "westeros", "westeros.csv")
 leffingwell_data.to_csv(file_path)

--- a/notebooks/Leffingwell.py
+++ b/notebooks/Leffingwell.py
@@ -14,10 +14,12 @@
 # ---
 
 import os
+
 import pandas as pd
+from rdkit import Chem
+
 import pyrfume
 from pyrfume import odorants
-from rdkit import Chem
 
 file_path = os.path.join(pyrfume.DATA, "westeros", "molecules.csv")
 leffingwell_data_raw = pd.read_csv(file_path, sep="\t")

--- a/notebooks/all-dragon.py
+++ b/notebooks/all-dragon.py
@@ -16,6 +16,7 @@
 import pandas as pd
 
 import pyrfume
+from pyrfume import odorants
 
 original = pyrfume.load_data("physicochemical/AllDragon-20190730-mayhew.csv")
 original.head()
@@ -24,8 +25,6 @@ new = pyrfume.load_data("physicochemical/ExtraEight.txt", delimiter="\t")
 new = new.set_index("NAME").sort_index()
 new.index.name = "PubChemID"
 new.index
-
-from pyrfume import odorants
 
 infos = odorants.from_cids(new.index)
 for info in infos:

--- a/notebooks/all-dragon.py
+++ b/notebooks/all-dragon.py
@@ -15,19 +15,21 @@
 
 import pandas as pd
 import pyrfume
-original = pyrfume.load_data('physicochemical/AllDragon-20190730-mayhew.csv')
+
+original = pyrfume.load_data("physicochemical/AllDragon-20190730-mayhew.csv")
 original.head()
 
-new = pyrfume.load_data('physicochemical/ExtraEight.txt', delimiter='\t')
-new = new.set_index('NAME').sort_index()
-new.index.name = 'PubChemID'
+new = pyrfume.load_data("physicochemical/ExtraEight.txt", delimiter="\t")
+new = new.set_index("NAME").sort_index()
+new.index.name = "PubChemID"
 new.index
 
 from pyrfume import odorants
+
 infos = odorants.from_cids(new.index)
 for info in infos:
-    new.loc[info['CID'], 'SMILES'] = info['IsomericSMILES']
-new = new[['SMILES']+[x for x in list(original) if x != 'SMILES']]
+    new.loc[info["CID"], "SMILES"] = info["IsomericSMILES"]
+new = new[["SMILES"] + [x for x in list(original) if x != "SMILES"]]
 new.head()
 
 assert list(original) == list(new)
@@ -36,4 +38,4 @@ df = pd.concat([original, new])
 df = df.groupby(level=0).first()  # Drop duplicate PubChem IDs
 df.shape
 
-pyrfume.save_data(df, 'physicochemical/AllDragon.csv')
+pyrfume.save_data(df, "physicochemical/AllDragon.csv")

--- a/notebooks/all-dragon.py
+++ b/notebooks/all-dragon.py
@@ -14,6 +14,7 @@
 # ---
 
 import pandas as pd
+
 import pyrfume
 
 original = pyrfume.load_data("physicochemical/AllDragon-20190730-mayhew.csv")

--- a/notebooks/all_cas.py
+++ b/notebooks/all_cas.py
@@ -14,8 +14,6 @@
 # ---
 
 # %matplotlib inline
-import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
 import pyrfume

--- a/notebooks/all_cas.py
+++ b/notebooks/all_cas.py
@@ -17,6 +17,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 import pyrfume
 from pyrfume.odorants import cids_to_cas
 

--- a/notebooks/all_cas.py
+++ b/notebooks/all_cas.py
@@ -20,20 +20,20 @@ import pandas as pd
 import pyrfume
 from pyrfume.odorants import cids_to_cas
 
-cids = pyrfume.load_data('odorants/all_cids.csv').index
+cids = pyrfume.load_data("odorants/all_cids.csv").index
 
 cas = cids_to_cas(cids)
 
 print("Out of %d molecules, %d have CAS numbers" % (len(cids), len([x for x in cas.values() if x])))
 
 counts = pd.Series([len(x) for x in cas.values()]).value_counts()
-counts.index.name = 'Number of unique CAS values'
-counts.name = 'Number of molecules'
+counts.index.name = "Number of unique CAS values"
+counts.name = "Number of molecules"
 counts.to_frame()
 
 to_save = pd.Series(cas)
-to_save.index.name = 'CID'
-to_save.name = 'CAS'
+to_save.index.name = "CID"
+to_save.name = "CAS"
 to_save.head()
 
-pyrfume.save_data(to_save.to_frame(), 'odorants/cid_to_cas.csv')
+pyrfume.save_data(to_save.to_frame(), "odorants/cid_to_cas.csv")

--- a/notebooks/arctander.py
+++ b/notebooks/arctander.py
@@ -24,6 +24,7 @@ df["InChiKey"] = df["InChiKey"].apply(
 )
 
 from tqdm.auto import tqdm
+
 from pyrfume.odorants import get_cid, get_cids
 
 for index, row in tqdm(df.iterrows(), total=df.shape[0]):

--- a/notebooks/arctander.py
+++ b/notebooks/arctander.py
@@ -14,25 +14,30 @@
 # ---
 
 import pyrfume
-df = pyrfume.load_data('arctander_1960/Arctander Master.xlsx')
+
+df = pyrfume.load_data("arctander_1960/Arctander Master.xlsx")
 
 from rdkit.Chem.rdinchi import InchiToInchiKey
-df['InChiKey'] = df['InChiKey'].apply(lambda x: InchiToInchiKey(x) if 'InChI=' in str(x) and str(x)!='nan' else x)
+
+df["InChiKey"] = df["InChiKey"].apply(
+    lambda x: InchiToInchiKey(x) if "InChI=" in str(x) and str(x) != "nan" else x
+)
 
 from tqdm.auto import tqdm
 from pyrfume.odorants import get_cid, get_cids
+
 for index, row in tqdm(df.iterrows(), total=df.shape[0]):
-    #if index < 215:
+    # if index < 215:
     #    continue
     cid = 0
-    for j, col in enumerate(['InChiKey', 'SMILES', 'CAS', 'ChemicalName']):
-        if not str(row[col]) == 'nan':
-            cid = get_cid(row[col], kind=(col if j<2 else 'name'))
+    for j, col in enumerate(["InChiKey", "SMILES", "CAS", "ChemicalName"]):
+        if not str(row[col]) == "nan":
+            cid = get_cid(row[col], kind=(col if j < 2 else "name"))
             if cid:
                 break
-    df.loc[index, 'new_CID'] = cid
+    df.loc[index, "new_CID"] = cid
 
-df[df['new_CID'].isnull()]
+df[df["new_CID"].isnull()]
 
 df.join(df[[]])
 
@@ -42,6 +47,4 @@ df.dropna(subset=["ChemicalName"]).shape
 
 x = dict(df.dropna(subset=["ChemicalName"]).set_index("ChemicalName")["Description"])
 
-dict(df.set_index('CID')["Description"])
-
-
+dict(df.set_index("CID")["Description"])

--- a/notebooks/arctander.py
+++ b/notebooks/arctander.py
@@ -13,11 +13,12 @@
 #     name: python3
 # ---
 
-import pyrfume
-
-from tqdm.auto import tqdm
-from pyrfume.odorants import get_cid
 from rdkit.Chem.rdinchi import InchiToInchiKey
+from tqdm.auto import tqdm
+
+import pyrfume
+from pyrfume.odorants import get_cid
+
 df = pyrfume.load_data("arctander_1960/Arctander Master.xlsx")
 
 df["InChiKey"] = df["InChiKey"].apply(

--- a/notebooks/arctander.py
+++ b/notebooks/arctander.py
@@ -15,17 +15,14 @@
 
 import pyrfume
 
-df = pyrfume.load_data("arctander_1960/Arctander Master.xlsx")
-
+from tqdm.auto import tqdm
+from pyrfume.odorants import get_cid
 from rdkit.Chem.rdinchi import InchiToInchiKey
+df = pyrfume.load_data("arctander_1960/Arctander Master.xlsx")
 
 df["InChiKey"] = df["InChiKey"].apply(
     lambda x: InchiToInchiKey(x) if "InChI=" in str(x) and str(x) != "nan" else x
 )
-
-from tqdm.auto import tqdm
-
-from pyrfume.odorants import get_cid, get_cids
 
 for index, row in tqdm(df.iterrows(), total=df.shape[0]):
     # if index < 215:

--- a/notebooks/bushdid.py
+++ b/notebooks/bushdid.py
@@ -20,11 +20,11 @@ from pyrfume import bushdid, odorants
 
 bushdid_data = bushdid.load_data()
 bushdid_cas_list = bushdid_data.index.unique()
-results = odorants.get_cids(bushdid_cas_list, kind='name', verbose=False)
+results = odorants.get_cids(bushdid_cas_list, kind="name", verbose=False)
 
-bushdid_data = pd.Series(results, name='CID').to_frame().join(bushdid_data)
+bushdid_data = pd.Series(results, name="CID").to_frame().join(bushdid_data)
 bushdid_data.head()
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = os.path.join(pyrfume.DATA, 'bushdid', 'bushdid.csv')
+file_path = os.path.join(pyrfume.DATA, "bushdid", "bushdid.csv")
 bushdid_data.to_csv(file_path)

--- a/notebooks/bushdid.py
+++ b/notebooks/bushdid.py
@@ -14,7 +14,9 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
 from pyrfume import bushdid, odorants
 

--- a/notebooks/cids_from_sources.py
+++ b/notebooks/cids_from_sources.py
@@ -16,11 +16,13 @@
 # %load_ext autoreload
 # %autoreload 2
 import os
-from pathlib import Path
 import pickle
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from rickpy import ProgressBar
+
 import pyrfume
 
 cids = {}

--- a/notebooks/cids_from_sources.py
+++ b/notebooks/cids_from_sources.py
@@ -15,15 +15,10 @@
 
 # %load_ext autoreload
 # %autoreload 2
-import os
 import pickle
-from pathlib import Path
-
-import numpy as np
 import pandas as pd
-from rickpy import ProgressBar
-
 import pyrfume
+from rickpy import get_sheet
 
 cids = {}
 DATA = pyrfume.DATA_DIR
@@ -126,7 +121,6 @@ cids["haddad-2008"] = set(df["CID"]) - {0}
 
 # ## U19 PIs
 
-from rickpy import get_sheet
 
 gerkin_sheet = "1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc"
 u19_sheet = "1B2sEj9pCk2_zS1X1Cg2ulAB4E_BWPboJBSvH4Gwc8fs"

--- a/notebooks/cids_from_sources.py
+++ b/notebooks/cids_from_sources.py
@@ -29,165 +29,166 @@ DATA = pyrfume.DATA_DIR
 # ## From Sigma Fragrance and Flavor Catalog (2014)
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = DATA / 'sigma_2014' / 'sigma.csv'
+file_path = DATA / "sigma_2014" / "sigma.csv"
 df = pd.read_csv(file_path)
-cids['sigma-2014'] = set(df['CID']) - {0}
+cids["sigma-2014"] = set(df["CID"]) - {0}
 
 # ## Dravnieks Atlas of Odor Character
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = DATA / 'dravnieks_1985' / 'dravnieks.csv'
+file_path = DATA / "dravnieks_1985" / "dravnieks.csv"
 df = pd.read_csv(file_path)
-cids['dravnieks-1985'] = set(df['CID']) - {0}
+cids["dravnieks-1985"] = set(df["CID"]) - {0}
 
 # ## Abraham et al, 2013
 
-file_path = DATA / 'abraham_2011' / 'abraham-2011-with-CIDs.csv'
+file_path = DATA / "abraham_2011" / "abraham-2011-with-CIDs.csv"
 df = pd.read_csv(file_path)
-cids['abraham-2013'] = set(df['CID']) - {0}
+cids["abraham-2013"] = set(df["CID"]) - {0}
 
 # ## Bushdid et al, 2014
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = DATA / 'bushdid_2014' / 'bushdid.csv'
+file_path = DATA / "bushdid_2014" / "bushdid.csv"
 df = pd.read_csv(file_path)
-cids['bushdid-2014'] = set(df['CID']) - {0}
+cids["bushdid-2014"] = set(df["CID"]) - {0}
 
 # ## Chae et al, 2019
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = DATA / 'chae_2019' / 'odorants.csv'
+file_path = DATA / "chae_2019" / "odorants.csv"
 df = pd.read_csv(file_path)
-cids['chae-2019'] = set(df['CID']) - {0}
+cids["chae-2019"] = set(df["CID"]) - {0}
 
 # ## Prestwick
 
-file_path = DATA / 'prestwick' / 'prestwick.csv'
+file_path = DATA / "prestwick" / "prestwick.csv"
 df = pd.read_csv(file_path)
-cids['prestwick'] = set(df['CID']) - {0}
+cids["prestwick"] = set(df["CID"]) - {0}
 
 # ## GRAS
 
-file_path = DATA / 'GRAS' / 'gras.csv'
+file_path = DATA / "GRAS" / "gras.csv"
 df = pd.read_csv(file_path)
-cids['gras'] = set(df['CID']) - {0}
+cids["gras"] = set(df["CID"]) - {0}
 
 # ## Sobel Lab (Weiss 2012, Snitz 2013)
 
-file_path = DATA / 'snitz_2013' / 'snitz.csv'
+file_path = DATA / "snitz_2013" / "snitz.csv"
 df = pd.read_csv(file_path)
-cids['sobel-2013'] = set(df['CID']) - {0}
+cids["sobel-2013"] = set(df["CID"]) - {0}
 
 # ## Leffingwell
 
-file_path = DATA / 'westeros' / 'westeros.csv'
+file_path = DATA / "westeros" / "westeros.csv"
 df = pd.read_csv(file_path)
-cids['leffingwell'] = set(df['CID']) - {0}
+cids["leffingwell"] = set(df["CID"]) - {0}
 
 # ## Davison
 
-file_path = DATA / 'davison_2007' / 'davison-katz.csv'
+file_path = DATA / "davison_2007" / "davison-katz.csv"
 df = pd.read_csv(file_path, index_col=0)
-cids['davison-2007'] = set(df['CID']) - {0}
+cids["davison-2007"] = set(df["CID"]) - {0}
 
 # ## FDB
 
-file_path = DATA / 'fragrancedb' / 'FragranceDB_CIDs.txt'
+file_path = DATA / "fragrancedb" / "FragranceDB_CIDs.txt"
 df = pd.read_csv(file_path)
-cids['fragrance-db'] = set(df['CID']) - {0}
+cids["fragrance-db"] = set(df["CID"]) - {0}
 
 # ## Mainland
 
-file_path = DATA / 'cabinets' / 'Mainland Odor Cabinet with CIDs.csv'
+file_path = DATA / "cabinets" / "Mainland Odor Cabinet with CIDs.csv"
 df = pd.read_csv(file_path)
-cids['mainland-cabinet'] = set(df['CID']) - {0}
+cids["mainland-cabinet"] = set(df["CID"]) - {0}
 
-file_path = DATA / 'mainland_intensity' / 'mainland-intensity-odorant-info.csv'
+file_path = DATA / "mainland_intensity" / "mainland-intensity-odorant-info.csv"
 df = pd.read_csv(file_path)
-cids['mainland-intensity'] = set(df['CID']) - {0}
+cids["mainland-intensity"] = set(df["CID"]) - {0}
 
-file_path = DATA / 'mainland_2015' / 'Odors.tsv'
-df = pd.read_csv(file_path, sep='\t')
-cids['mainland-receptors'] = set(df['CID'].dropna().astype(int)) - {0}
+file_path = DATA / "mainland_2015" / "Odors.tsv"
+df = pd.read_csv(file_path, sep="\t")
+cids["mainland-receptors"] = set(df["CID"].dropna().astype(int)) - {0}
 
 # ## Enantiomers
 
-file_path = DATA / 'shadmany' / 'enantiomers.csv'
+file_path = DATA / "shadmany" / "enantiomers.csv"
 df = pd.read_csv(file_path)
-cids['enantiomers'] = set(df['CID']) - {0}
+cids["enantiomers"] = set(df["CID"]) - {0}
 
 # ## Haddad (just the clusters)
 
-file_path = DATA / 'haddad_2008' / 'haddad-clusters.csv'
+file_path = DATA / "haddad_2008" / "haddad-clusters.csv"
 df = pd.read_csv(file_path)
-cids['haddad-2008'] = set(df['CID']) - {0}
+cids["haddad-2008"] = set(df["CID"]) - {0}
 
 # ## U19 PIs
 
 from rickpy import get_sheet
-gerkin_sheet = '1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc'
-u19_sheet = '1B2sEj9pCk2_zS1X1Cg2ulAB4E_BWPboJBSvH4Gwc8fs'
+
+gerkin_sheet = "1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc"
+u19_sheet = "1B2sEj9pCk2_zS1X1Cg2ulAB4E_BWPboJBSvH4Gwc8fs"
 dfs = {}
-dfs['gerkin-cabinet'] = get_sheet(gerkin_sheet, 'gerkin-compounds').set_index('CID')
-dfs['smith-cabinet'] = get_sheet(gerkin_sheet, 'smith-compounds').set_index('CID')
-dfs['rinberg-glomeruli'] = get_sheet(u19_sheet, 'rinberg').set_index('CID')
-dfs['fleischmann-cabinet'] = get_sheet(u19_sheet, 'fleischmann').set_index('CID')
-dfs['datta-cabinet'] = get_sheet(u19_sheet, 'datta').set_index('CID')
-dfs['bozza-cabinet'] = get_sheet(u19_sheet, 'bozza').set_index('CID')
+dfs["gerkin-cabinet"] = get_sheet(gerkin_sheet, "gerkin-compounds").set_index("CID")
+dfs["smith-cabinet"] = get_sheet(gerkin_sheet, "smith-compounds").set_index("CID")
+dfs["rinberg-glomeruli"] = get_sheet(u19_sheet, "rinberg").set_index("CID")
+dfs["fleischmann-cabinet"] = get_sheet(u19_sheet, "fleischmann").set_index("CID")
+dfs["datta-cabinet"] = get_sheet(u19_sheet, "datta").set_index("CID")
+dfs["bozza-cabinet"] = get_sheet(u19_sheet, "bozza").set_index("CID")
 
 for name, df in dfs.items():
     cids[name] = set(df.index) - {0}
 
 # ## Goodscents
 
-file_path = DATA / 'goodscents' / 'goodscents_cids.txt'
+file_path = DATA / "goodscents" / "goodscents_cids.txt"
 df = pd.read_csv(file_path, index_col=False)
-cids['goodscents'] = set(df['CID']) - {0}
+cids["goodscents"] = set(df["CID"]) - {0}
 
 # ## Arctander
 
-file_path = DATA / 'arctander_1960' / 'arctander_cids.txt'
+file_path = DATA / "arctander_1960" / "arctander_cids.txt"
 df = pd.read_csv(file_path, index_col=False)
-cids['arctander-1960'] = set(df['CID']) - {0}
+cids["arctander-1960"] = set(df["CID"]) - {0}
 
 # ## Flavornet
 
-file_path = DATA / 'flavornet' / 'flavornet.csv'
+file_path = DATA / "flavornet" / "flavornet.csv"
 df = pd.read_csv(file_path)
-cids['flavornet'] = set(df['CID']) - {0}
+cids["flavornet"] = set(df["CID"]) - {0}
 
 # ## Scott et al, 2014
 
-file_path = DATA / 'scott_2014' / 'data.csv'
+file_path = DATA / "scott_2014" / "data.csv"
 df = pd.read_csv(file_path)
-cids['scott-2014'] = set(df['CID']) - {0}
+cids["scott-2014"] = set(df["CID"]) - {0}
 
 # ## Superscent
 
-file_path = DATA / 'superscent' / 'superscent_cids.txt'
+file_path = DATA / "superscent" / "superscent_cids.txt"
 df = pd.read_csv(file_path)
-cids['superscent'] = set(df['CID']) - {0}
+cids["superscent"] = set(df["CID"]) - {0}
 
 # ## SenseLab
 
-file_path = DATA / 'senselab' / 'senselab.csv'
+file_path = DATA / "senselab" / "senselab.csv"
 df = pd.read_csv(file_path)
-cids['senselab'] = set(df['CID']) - {0}
+cids["senselab"] = set(df["CID"]) - {0}
 
-file_path = DATA / 'wakayama_2019' / 'wakayama-intensity_with-CIDs.txt'
-df = pd.read_csv(file_path, sep='\t')
-cids['wakayama-2019'] = set(df['CID']) - {0}
+file_path = DATA / "wakayama_2019" / "wakayama-intensity_with-CIDs.txt"
+df = pd.read_csv(file_path, sep="\t")
+cids["wakayama-2019"] = set(df["CID"]) - {0}
 
 # ## Save
 
-file_path = DATA / 'odorants' / 'cids.pkl'
-with open(file_path, 'wb') as f:
+file_path = DATA / "odorants" / "cids.pkl"
+with open(file_path, "wb") as f:
     pickle.dump(cids, f)
 
 # ## Load
 
 # +
-#with open(file_path, 'rb') as f:
+# with open(file_path, 'rb') as f:
 #    cids2 = pickle.load(f)
 # -
 
@@ -197,10 +198,10 @@ all_cids = set()
 for key in cids:
     all_cids |= cids[key]
 all_cids = pd.DataFrame(index=sorted(list(all_cids)), columns=sorted(list(cids))).fillna(0)
-all_cids.index.name = 'CID'
+all_cids.index.name = "CID"
 for key in cids:
     all_cids.loc[list(cids[key]), key] = 1
-file_path = DATA / 'odorants' / 'all_cids.csv'
+file_path = DATA / "odorants" / "all_cids.csv"
 all_cids.to_csv(file_path)
 
 all_cids.shape

--- a/notebooks/cids_from_sources.py
+++ b/notebooks/cids_from_sources.py
@@ -16,9 +16,11 @@
 # %load_ext autoreload
 # %autoreload 2
 import pickle
+
 import pandas as pd
-import pyrfume
 from rickpy import get_sheet
+
+import pyrfume
 
 cids = {}
 DATA = pyrfume.DATA_DIR

--- a/notebooks/cids_smiles_to_sdf.py
+++ b/notebooks/cids_smiles_to_sdf.py
@@ -20,10 +20,10 @@ import pandas as pd
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.Chem.SaltRemover import SaltRemover
+from rickpy import ProgressBar
 
 import pyrfume
 from pyrfume import odorants
-from rickpy import ProgressBar
 
 # -
 

--- a/notebooks/cids_smiles_to_sdf.py
+++ b/notebooks/cids_smiles_to_sdf.py
@@ -24,16 +24,17 @@ from rdkit.Chem.SaltRemover import SaltRemover
 import pyrfume
 from pyrfume import odorants
 from rickpy import ProgressBar
+
 # -
 
-file_path = os.path.join(pyrfume.DATA, 'all_cids_properties.csv')
-df = pd.read_csv(file_path).set_index('CID')
+file_path = os.path.join(pyrfume.DATA, "all_cids_properties.csv")
+df = pd.read_csv(file_path).set_index("CID")
 
 # ## Make 3D optimized versions of the molecules
 
 # +
 # Make basic mol objects
-mols = {cid: Chem.MolFromSmiles(smi) for cid, smi in df['IsomericSMILES'].items()}
+mols = {cid: Chem.MolFromSmiles(smi) for cid, smi in df["IsomericSMILES"].items()}
 
 # Then optimize them
 s = SaltRemover()
@@ -41,18 +42,18 @@ p = ProgressBar(len(df))
 for i, (cid, mol) in enumerate(mols.items()):
     p.animate(i, status=cid)
     try:
-        mol.SetProp("_Name","%d: %s" % (cid, df.loc[cid, 'IsomericSMILES']))
+        mol.SetProp("_Name", "%d: %s" % (cid, df.loc[cid, "IsomericSMILES"]))
         mol = s.StripMol(mol, dontRemoveEverything=True)
         mol = Chem.AddHs(mol)
         AllChem.Compute2DCoords(mol)
         AllChem.EmbedMolecule(mol)
-        AllChem.UFFOptimizeMolecule(mol) # Is this deterministic?  
+        AllChem.UFFOptimizeMolecule(mol)  # Is this deterministic?
     except Exception as e:
-        p.log('Exception for %d: %s' % (cid, e))
+        p.log("Exception for %d: %s" % (cid, e))
         mols[cid] = None
     else:
         mols[cid] = mol
-        
+
 # Remove CIDs without a successful optimization
 mols = {cid: mol for cid, mol in mols.items() if mol}
 # -
@@ -61,7 +62,7 @@ print("%d mol files successfully optimized from %d CIDs" % (len(mols), len(df)))
 
 # ## Write to an SDF file
 
-file_path = os.path.join(pyrfume.DATA, 'all_cids.sdf')
+file_path = os.path.join(pyrfume.DATA, "all_cids.sdf")
 f = Chem.SDWriter(file_path)
 for cid, mol in mols.items():
     f.write(mol)
@@ -69,7 +70,6 @@ f.close()
 
 # Write the last molecule to a mol file
 mol_block = Chem.MolToMolBlock(mol)
-file_path = os.path.join(pyrfume.DATA, 'random.mol')
-with open(file_path,'w+') as f:
-    print(mol_block, 
-          file=f)
+file_path = os.path.join(pyrfume.DATA, "random.mol")
+with open(file_path, "w+") as f:
+    print(mol_block, file=f)

--- a/notebooks/cids_smiles_to_sdf.py
+++ b/notebooks/cids_smiles_to_sdf.py
@@ -23,7 +23,6 @@ from rdkit.Chem.SaltRemover import SaltRemover
 from rickpy import ProgressBar
 
 import pyrfume
-from pyrfume import odorants
 
 # -
 

--- a/notebooks/cids_to_smiles.py
+++ b/notebooks/cids_to_smiles.py
@@ -18,25 +18,23 @@ import pyrfume
 from pyrfume import odorants
 
 # Load the table of CIDs by sources
-file_path = pyrfume.DATA_DIR / 'odorants' / 'all_cids.csv'
-all_cids = pd.read_csv(file_path).set_index('CID')
+file_path = pyrfume.DATA_DIR / "odorants" / "all_cids.csv"
+all_cids = pd.read_csv(file_path).set_index("CID")
 
 # +
 # Get info from PubChem
 info = odorants.from_cids(all_cids.index)
 
 # Turn the info into a dataframe
-info = pd.DataFrame.from_records(info).set_index('CID')
+info = pd.DataFrame.from_records(info).set_index("CID")
 info.head()
 # -
 
-# Join the CIDs and sources with the PubCheminfo 
+# Join the CIDs and sources with the PubCheminfo
 df = info.join(all_cids)
-df = df.rename(columns={'MolecularWeight': 'MW',
-                        'IsomericSMILES': 'SMILES',
-                        'name': 'Name'})
-df = df[['Name', 'MW', 'SMILES', 'IUPACName'] + list(df.columns[4:])]
+df = df.rename(columns={"MolecularWeight": "MW", "IsomericSMILES": "SMILES", "name": "Name"})
+df = df[["Name", "MW", "SMILES", "IUPACName"] + list(df.columns[4:])]
 df.head()
 
-file_path = pyrfume.DATA_DIR / 'odorants' / 'all_cids_properties.csv'
+file_path = pyrfume.DATA_DIR / "odorants" / "all_cids_properties.csv"
 df.to_csv(file_path)

--- a/notebooks/cids_to_smiles.py
+++ b/notebooks/cids_to_smiles.py
@@ -14,6 +14,7 @@
 # ---
 
 import pandas as pd
+
 import pyrfume
 from pyrfume import odorants
 

--- a/notebooks/clean-fig.py
+++ b/notebooks/clean-fig.py
@@ -18,8 +18,8 @@
 import re
 
 import pyrfume
-from pyrfume.odorants import get_cids
 from pyrfume.cabinets import get_mainland
+from pyrfume.odorants import get_cids
 
 # Load the data extracted by Tabula using the "Stream" method
 df = pyrfume.load_data("IFRA_FIG/ifra-fragrance-ingredient-glossary---oct-2019.csv")

--- a/notebooks/clean-fig.py
+++ b/notebooks/clean-fig.py
@@ -17,10 +17,9 @@
 
 import re
 
-import pandas as pd
-
 import pyrfume
 from pyrfume.odorants import get_cids
+from pyrfume.cabinets import get_mainland
 
 # Load the data extracted by Tabula using the "Stream" method
 df = pyrfume.load_data("IFRA_FIG/ifra-fragrance-ingredient-glossary---oct-2019.csv")
@@ -44,10 +43,10 @@ df = df.loc[~df.index.isin(overflow_indices)]
 
 # Fix problematic CAS numbers
 for index, cas in df["CAS number"].items():
-    if not re.match("[0-9]+\-[0-9]+\-[0-9]+", cas):
+    if not re.match(r"[0-9]+-[0-9]+-[0-9]+", cas):
         print("Fixing %s" % cas)
         cas = cas.replace("(", "").replace(")", "")
-        assert re.match("[0-9]+\-[0-9]+\-[0-9]+", cas)
+        assert re.match(r"[0-9]+-[0-9]+-[0-9]+", cas)
         df.loc[index, "CAS number"] = cas
 
 # + jupyter={"outputs_hidden": true}
@@ -71,7 +70,6 @@ pyrfume.save_data(df, "IFRA_FIG/ifra_fig.csv")
 
 pyrfume.load_data("IFRA_FIG/ifra_fig.csv")
 
-from pyrfume.cabinets import get_mainland
 
 df_mainland = get_mainland()
 len(set(df_mainland["CAS"]).intersection(df["CAS number"]))

--- a/notebooks/clean-fig.py
+++ b/notebooks/clean-fig.py
@@ -15,10 +15,12 @@
 
 # ### Clean the extracted FIG pdf data
 
+import re
+
 import pandas as pd
+
 import pyrfume
 from pyrfume.odorants import get_cids
-import re
 
 # Load the data extracted by Tabula using the "Stream" method
 df = pyrfume.load_data("IFRA_FIG/ifra-fragrance-ingredient-glossary---oct-2019.csv")

--- a/notebooks/clean-fig.py
+++ b/notebooks/clean-fig.py
@@ -19,71 +19,78 @@ import pandas as pd
 import pyrfume
 from pyrfume.odorants import get_cids
 import re
+
 # Load the data extracted by Tabula using the "Stream" method
-df = pyrfume.load_data('IFRA_FIG/ifra-fragrance-ingredient-glossary---oct-2019.csv')
+df = pyrfume.load_data("IFRA_FIG/ifra-fragrance-ingredient-glossary---oct-2019.csv")
 
 df = df.reset_index()
 df.head()
 
 # These are the indices of overflow cells, which only contain the last few characters of the previous cell's molecule name
-overflow_indices = df.index[df['CAS number'].isnull()]
+overflow_indices = df.index[df["CAS number"].isnull()]
 overflow_indices
 
 # Merge those last few characters into the previous cell's molecule name
 for i in overflow_indices:
-    df.loc[i-1, 'Principal name'] = '%s%s'% (df.loc[i-1, 'Principal name'], df.loc[i, 'Principal name'])
+    df.loc[i - 1, "Principal name"] = "%s%s" % (
+        df.loc[i - 1, "Principal name"],
+        df.loc[i, "Principal name"],
+    )
 
 # Delete those overflow rows
 df = df.loc[~df.index.isin(overflow_indices)]
 
 # Fix problematic CAS numbers
-for index, cas in df['CAS number'].items():
-    if not re.match('[0-9]+\-[0-9]+\-[0-9]+', cas):
+for index, cas in df["CAS number"].items():
+    if not re.match("[0-9]+\-[0-9]+\-[0-9]+", cas):
         print("Fixing %s" % cas)
-        cas = cas.replace('(','').replace(')','')
-        assert re.match('[0-9]+\-[0-9]+\-[0-9]+', cas)
-        df.loc[index, 'CAS number'] = cas
+        cas = cas.replace("(", "").replace(")", "")
+        assert re.match("[0-9]+\-[0-9]+\-[0-9]+", cas)
+        df.loc[index, "CAS number"] = cas
 
 # + jupyter={"outputs_hidden": true}
 # Get CIDs for these CAS numbers
 # Many of these CAS numbers are for substances, not compounds, and so have SIDs instead (not yet supported)
-cas_cids_dict = get_cids(df['CAS number'])
+cas_cids_dict = get_cids(df["CAS number"])
 # -
 
 # Add CIDs to the dataframe
 for cas, cid in cas_cids_dict.items():
-    df.loc[df['CAS number']==cas, 'CID'] = cid
+    df.loc[df["CAS number"] == cas, "CID"] = cid
 # Convert CIDs to integers
-df.loc[:, 'CID'] = df.loc[:, 'CID'].astype(int)
+df.loc[:, "CID"] = df.loc[:, "CID"].astype(int)
 df.head()
 
 # Use CID as the index and sort
-df = df.set_index('CID').sort_index()
+df = df.set_index("CID").sort_index()
 df.head()
 
-pyrfume.save_data(df, 'IFRA_FIG/ifra_fig.csv')
+pyrfume.save_data(df, "IFRA_FIG/ifra_fig.csv")
 
-pyrfume.load_data('IFRA_FIG/ifra_fig.csv')
+pyrfume.load_data("IFRA_FIG/ifra_fig.csv")
 
 from pyrfume.cabinets import get_mainland
+
 df_mainland = get_mainland()
-len(set(df_mainland['CAS']).intersection(df['CAS number']))
+len(set(df_mainland["CAS"]).intersection(df["CAS number"]))
 
 len(df_mainland.index.intersection(df.index))
 
-df[df.index.isin(df_mainland.index)]#
+df[df.index.isin(df_mainland.index)]  #
 
-x = df_mainland.join(df, how='inner')[['CAS', 'CAS number', 'Primary descriptor', 'Descriptor 2', 'Descriptor 2']]
+x = df_mainland.join(df, how="inner")[
+    ["CAS", "CAS number", "Primary descriptor", "Descriptor 2", "Descriptor 2"]
+]
 
 for cid in x.index:
-    if cid>0:
-        y = x.loc[cid, 'CAS'] != x.loc[cid, 'CAS number']
+    if cid > 0:
+        y = x.loc[cid, "CAS"] != x.loc[cid, "CAS number"]
         if isinstance(y, bool):
             if y:
                 print(cid)
         elif all(y):
             print(cid)
 
-x.columns = ['Mainland CAS', 'FIG CAS', 'Primary descriptor', 'Descriptor 2', 'Descriptor 3']
+x.columns = ["Mainland CAS", "FIG CAS", "Primary descriptor", "Descriptor 2", "Descriptor 3"]
 
-x.to_csv('FIG-in-Mainland.csv')
+x.to_csv("FIG-in-Mainland.csv")

--- a/notebooks/demo.py
+++ b/notebooks/demo.py
@@ -12,5 +12,3 @@
 #     language: python
 #     name: python3
 # ---
-
-

--- a/notebooks/distance_distributions.py
+++ b/notebooks/distance_distributions.py
@@ -17,8 +17,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 import pyrfume
-from pyrfume import features, snitz, haddad
+from pyrfume import features, haddad, snitz
 
 distances = {}
 

--- a/notebooks/distance_distributions.py
+++ b/notebooks/distance_distributions.py
@@ -25,29 +25,33 @@ distances = {}
 # Load minmaxed, imputed Dragon features (cached from previous work) for all Pyrfume odorants
 # (Alternatively, load raw Dragon features and apply `features.clean_dragon`.)
 # Here we use minimax scaling instead of standard scaling because that is what the Snitz paper used.
-minmax_scaled_dragon = features.load_dragon(suffix='-cleaned-minmaxed-imputed')
+minmax_scaled_dragon = features.load_dragon(suffix="-cleaned-minmaxed-imputed")
 # Use the subset of features identified in Haddad and compute a cosine angle distance between each pair of odorants
-distances['snitz'] = snitz.get_snitz_distances(minmax_scaled_dragon)
+distances["snitz"] = snitz.get_snitz_distances(minmax_scaled_dragon)
 # Show the first 5 rows
-distances['snitz'].head()
+distances["snitz"].head()
 
-# Load scaled, imputed Dragon features (cached from previous work) for all Pyrfume odorants; 
-# (Alternatively, load raw Dragon features and apply `features.clean_dragon`.)  
-standard_scaled_dragon = features.load_dragon(suffix='-cleaned-standardized-imputed')
+# Load scaled, imputed Dragon features (cached from previous work) for all Pyrfume odorants;
+# (Alternatively, load raw Dragon features and apply `features.clean_dragon`.)
+standard_scaled_dragon = features.load_dragon(suffix="-cleaned-standardized-imputed")
 # Use the subset of features identified in Haddad and compute a Euclidean distance between each pair of odorants
-distances['haddad'] = haddad.get_haddad_distances(standard_scaled_dragon)
+distances["haddad"] = haddad.get_haddad_distances(standard_scaled_dragon)
 # Show the first 5 rows
-distances['haddad'].head()
+distances["haddad"].head()
 
 # +
-nondiagonal = distances['haddad'].values[np.triu_indices(distances['haddad'].shape[0], 1)]
-density, bins, _ = plt.hist(nondiagonal, bins=np.linspace(0, 25, 100), density=True, cumulative=True)
-shift = (bins[1]-bins[0])/2
-haddad_density = pd.DataFrame(density, columns=['Cumulative Probability'], index=bins[:-1]+shift)
-pyrfume.save_data(haddad_density, 'haddad_2008/haddad_cumulative_probability.csv')
+nondiagonal = distances["haddad"].values[np.triu_indices(distances["haddad"].shape[0], 1)]
+density, bins, _ = plt.hist(
+    nondiagonal, bins=np.linspace(0, 25, 100), density=True, cumulative=True
+)
+shift = (bins[1] - bins[0]) / 2
+haddad_density = pd.DataFrame(density, columns=["Cumulative Probability"], index=bins[:-1] + shift)
+pyrfume.save_data(haddad_density, "haddad_2008/haddad_cumulative_probability.csv")
 
-nondiagonal = distances['snitz'].values[np.triu_indices(distances['snitz'].shape[0], 1)]
-density, bins, _ = plt.hist(nondiagonal, bins=np.linspace(0, 0.5, 100), density=True, cumulative=True)
-shift = (bins[1]-bins[0])/2
-snitz_density = pd.DataFrame(density, columns=['Cumulative Probability'], index=bins[:-1]+shift)
-pyrfume.save_data(snitz_density, 'snitz_2013/snitz_cumulative_probability.csv')
+nondiagonal = distances["snitz"].values[np.triu_indices(distances["snitz"].shape[0], 1)]
+density, bins, _ = plt.hist(
+    nondiagonal, bins=np.linspace(0, 0.5, 100), density=True, cumulative=True
+)
+shift = (bins[1] - bins[0]) / 2
+snitz_density = pd.DataFrame(density, columns=["Cumulative Probability"], index=bins[:-1] + shift)
+pyrfume.save_data(snitz_density, "snitz_2013/snitz_cumulative_probability.csv")

--- a/notebooks/dragon-clean-impute.py
+++ b/notebooks/dragon-clean-impute.py
@@ -17,9 +17,11 @@
 
 # +
 import warnings
+
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 from pyrfume import features
+
 # -
 
 df = features.load_dragon()
@@ -28,20 +30,18 @@ df.shape
 df_cleaned = features.clean_features(df)
 df_cleaned.shape
 
-df_cleaned_minmaxed = features.scale_features(df_cleaned, 'minmax')
+df_cleaned_minmaxed = features.scale_features(df_cleaned, "minmax")
 df_cleaned_minmaxed.shape
 
-df_cleaned_standardized = features.scale_features(df_cleaned, 'standardize')
+df_cleaned_standardized = features.scale_features(df_cleaned, "standardize")
 df_cleaned_standardized.shape
 
 df_cleaned_minmaxed_imputed = features.impute_features(df_cleaned_minmaxed)
 df_cleaned_minmaxed_imputed.shape
 
-features.save_dragon(df_cleaned_minmaxed_imputed, '-cleaned-minmaxed-imputed')
+features.save_dragon(df_cleaned_minmaxed_imputed, "-cleaned-minmaxed-imputed")
 
 df_cleaned_standardized_imputed = features.impute_features(df_cleaned_standardized)
 df_cleaned_standardized_imputed.shape
 
-features.save_dragon(df_cleaned_standardized_imputed, '-cleaned-standardized-imputed')
-
-
+features.save_dragon(df_cleaned_standardized_imputed, "-cleaned-standardized-imputed")

--- a/notebooks/dragon-clean-impute.py
+++ b/notebooks/dragon-clean-impute.py
@@ -17,6 +17,7 @@
 
 # +
 import warnings
+
 from pyrfume import features
 
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/notebooks/dragon-clean-impute.py
+++ b/notebooks/dragon-clean-impute.py
@@ -17,12 +17,9 @@
 
 # +
 import warnings
-
-warnings.filterwarnings("ignore", category=FutureWarning)
-
 from pyrfume import features
 
-# -
+warnings.filterwarnings("ignore", category=FutureWarning)
 
 df = features.load_dragon()
 df.shape

--- a/notebooks/dragon-haddad-mordred-alignment.py
+++ b/notebooks/dragon-haddad-mordred-alignment.py
@@ -27,57 +27,61 @@ df.index = df.index.astype(int)
 df = df.sort_index()
 df.head()
 df.to_csv('data/cids-smiles-dragon.txt')
-""";
+"""
 
 dfs = {}
-dfs['dragon'] = pd.read_csv('data/cids-smiles-dragon.txt').set_index('CID')
-dfs['mordred'] = pd.read_csv('data/mordred-features.csv').set_index('CID')
+dfs["dragon"] = pd.read_csv("data/cids-smiles-dragon.txt").set_index("CID")
+dfs["mordred"] = pd.read_csv("data/mordred-features.csv").set_index("CID")
 
-dfs['dragon'].head()
+dfs["dragon"].head()
 
-dfs['mordred'].head()
+dfs["mordred"].head()
 
 # Only one molecule has mordred features but no dragon features
-dfs['mordred'].index.difference(dfs['dragon'].index)
+dfs["mordred"].index.difference(dfs["dragon"].index)
 
-dfs['mordred'] = dfs['mordred'].loc[dfs['dragon'].index].iloc[:, 3:]
-dfs['mordred'].head()
+dfs["mordred"] = dfs["mordred"].loc[dfs["dragon"].index].iloc[:, 3:]
+dfs["mordred"].head()
 
-dfs['dragon'] = dfs['dragon'].iloc[:, 1:]
-dfs['dragon'].head()
+dfs["dragon"] = dfs["dragon"].iloc[:, 1:]
+dfs["dragon"].head()
 
 from sklearn.preprocessing import StandardScaler
+
 ss = {}
-for kind in ['dragon', 'mordred']:
-    ss[kind] = StandardScaler() 
-    good = dfs[kind].columns[dfs[kind].isnull().sum()<500]
+for kind in ["dragon", "mordred"]:
+    ss[kind] = StandardScaler()
+    good = dfs[kind].columns[dfs[kind].isnull().sum() < 500]
     df = dfs[kind][good]
-    scaled = ss[kind].fit_transform(df.astype('float'))
-    dfs[kind+'_good'] = pd.DataFrame(scaled, index=df.index, columns=df.columns)
+    scaled = ss[kind].fit_transform(df.astype("float"))
+    dfs[kind + "_good"] = pd.DataFrame(scaled, index=df.index, columns=df.columns)
 
 from fancyimpute import KNN
+
 knns = {}
-for kind in ['dragon', 'mordred']:
+for kind in ["dragon", "mordred"]:
     knns[kind] = KNN(k=5)
-    df = dfs[kind+'_good']
+    df = dfs[kind + "_good"]
     imputed = knns[kind].fit_transform(df.values)
-    dfs[kind+'_imputed'] = pd.DataFrame(imputed, index=df.index, columns=df.columns)
+    dfs[kind + "_imputed"] = pd.DataFrame(imputed, index=df.index, columns=df.columns)
 
 from sklearn.linear_model import Lasso
-lasso = Lasso(alpha=0.1)
-lasso.fit(dfs['dragon_imputed'].values, dfs['mordred_imputed'].values[:,:])
 
-predicted = lasso.predict(dfs['dragon_imputed'])
-observed = dfs['mordred_imputed']
+lasso = Lasso(alpha=0.1)
+lasso.fit(dfs["dragon_imputed"].values, dfs["mordred_imputed"].values[:, :])
+
+predicted = lasso.predict(dfs["dragon_imputed"])
+observed = dfs["mordred_imputed"]
 rs = np.zeros(observed.shape[1])
 for i, col in enumerate(observed):
-    rs[i] = np.corrcoef(observed[col], predicted[:, i])[0,1]
+    rs[i] = np.corrcoef(observed[col], predicted[:, i])[0, 1]
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
 plt.plot(sorted(sorted(rs)))
 
-plt.plot(np.linspace(0,1,len(lasso.coef_.ravel())),sorted(np.abs(lasso.coef_.ravel()))[::-1])
-plt.xscale('log')
-plt.xlabel('Quantile rank (Top X% of coefficients)')
-plt.ylabel('Absolute value of coefficient');
+plt.plot(np.linspace(0, 1, len(lasso.coef_.ravel())), sorted(np.abs(lasso.coef_.ravel()))[::-1])
+plt.xscale("log")
+plt.xlabel("Quantile rank (Top X% of coefficients)")
+plt.ylabel("Absolute value of coefficient")

--- a/notebooks/dragon-haddad-mordred-alignment.py
+++ b/notebooks/dragon-haddad-mordred-alignment.py
@@ -13,12 +13,12 @@
 #     name: python3
 # ---
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import StandardScaler
 from fancyimpute import KNN
 from sklearn.linear_model import Lasso
-import matplotlib.pyplot as plt
+from sklearn.preprocessing import StandardScaler
 
 # Fix the file that Emily sent me
 """

--- a/notebooks/dragon-haddad-mordred-alignment.py
+++ b/notebooks/dragon-haddad-mordred-alignment.py
@@ -15,6 +15,10 @@
 
 import numpy as np
 import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from fancyimpute import KNN
+from sklearn.linear_model import Lasso
+import matplotlib.pyplot as plt
 
 # Fix the file that Emily sent me
 """
@@ -46,8 +50,6 @@ dfs["mordred"].head()
 dfs["dragon"] = dfs["dragon"].iloc[:, 1:]
 dfs["dragon"].head()
 
-from sklearn.preprocessing import StandardScaler
-
 ss = {}
 for kind in ["dragon", "mordred"]:
     ss[kind] = StandardScaler()
@@ -56,16 +58,12 @@ for kind in ["dragon", "mordred"]:
     scaled = ss[kind].fit_transform(df.astype("float"))
     dfs[kind + "_good"] = pd.DataFrame(scaled, index=df.index, columns=df.columns)
 
-from fancyimpute import KNN
-
 knns = {}
 for kind in ["dragon", "mordred"]:
     knns[kind] = KNN(k=5)
     df = dfs[kind + "_good"]
     imputed = knns[kind].fit_transform(df.values)
     dfs[kind + "_imputed"] = pd.DataFrame(imputed, index=df.index, columns=df.columns)
-
-from sklearn.linear_model import Lasso
 
 lasso = Lasso(alpha=0.1)
 lasso.fit(dfs["dragon_imputed"].values, dfs["mordred_imputed"].values[:, :])
@@ -77,7 +75,6 @@ for i, col in enumerate(observed):
     rs[i] = np.corrcoef(observed[col], predicted[:, i])[0, 1]
 
 # %matplotlib inline
-import matplotlib.pyplot as plt
 
 plt.plot(sorted(sorted(rs)))
 

--- a/notebooks/dravnieks.py
+++ b/notebooks/dravnieks.py
@@ -14,9 +14,11 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
-from pyrfume import odorants, dravnieks
+from pyrfume import dravnieks, odorants
 
 cas, descriptors, data = dravnieks.get_data()
 drav = pd.DataFrame.from_dict(data).T.round(2)

--- a/notebooks/dravnieks.py
+++ b/notebooks/dravnieks.py
@@ -23,11 +23,11 @@ drav = pd.DataFrame.from_dict(data).T.round(2)
 
 # Turn CAS into CIDs
 cas_list = list(data.keys())
-results = odorants.get_cids(cas_list, kind='name', verbose=False)
+results = odorants.get_cids(cas_list, kind="name", verbose=False)
 
-drav = pd.Series(results, name='CID').to_frame().join(drav)
+drav = pd.Series(results, name="CID").to_frame().join(drav)
 drav.head()
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = os.path.join(pyrfume.DATA, 'dravnieks', 'dravnieks.csv')
+file_path = os.path.join(pyrfume.DATA, "dravnieks", "dravnieks.csv")
 drav.to_csv(file_path)

--- a/notebooks/flavornet.py
+++ b/notebooks/flavornet.py
@@ -13,11 +13,12 @@
 #     name: python3
 # ---
 
+import os
+from urllib.request import urlopen
+
 # +
 import bs4
-import os
 import pandas as pd
-from urllib.request import urlopen
 
 import pyrfume
 from pyrfume import odorants

--- a/notebooks/flavornet.py
+++ b/notebooks/flavornet.py
@@ -21,23 +21,24 @@ from urllib.request import urlopen
 
 import pyrfume
 from pyrfume import odorants
+
 # -
 
-url = 'http://www.flavornet.org/cas.html'
+url = "http://www.flavornet.org/cas.html"
 f = urlopen(url)
 html = f.read()
 soup = bs4.BeautifulSoup(html)
 
 cas_list = []
-rows = soup.find('table').find_all('tr')
+rows = soup.find("table").find_all("tr")
 for row in rows[1:]:
-    cas = row.find('td').text
+    cas = row.find("td").text
     cas_list.append(cas)
 
-cids = odorants.get_cids(cas_list, kind='name')
+cids = odorants.get_cids(cas_list, kind="name")
 
-df = pd.Series(cids, name='CID').to_frame()
+df = pd.Series(cids, name="CID").to_frame()
 df.head()
 
-file_path = os.path.join(pyrfume.DATA, 'flavornet.csv')
+file_path = os.path.join(pyrfume.DATA, "flavornet.csv")
 df.to_csv(file_path)

--- a/notebooks/generate-mordred.py
+++ b/notebooks/generate-mordred.py
@@ -17,7 +17,8 @@ import pandas as pd
 from mordred import Calculator
 from mordred import descriptors as all_descriptors
 from rdkit import Chem
-from rdkit.Chem import AllChem, SaltRemover, rdmolfiles
+from rdkit.Chem import AllChem, SaltRemover
+from fancyimpute import KNN
 
 smiles = pd.read_csv("data/snitz-odorant-info.csv").set_index("CID")["IsomericSMILES"]
 
@@ -51,24 +52,18 @@ results.head()
 
 results.shape
 
-
-# +
 def fix(x):
     try:
         x = float(x)
-    except:
+    except Exception:
         x = None
     return x
 
-
 results = results.applymap(fix)
-# -
 
 frac_bad = results.isnull().mean()
 good = frac_bad[frac_bad < 0.3].index
 results = results.loc[:, good]
-
-from fancyimpute import KNN
 
 knn = KNN(k=5)
 results[:] = knn.fit_transform(results.values)
@@ -76,3 +71,4 @@ results[:] = knn.fit_transform(results.values)
 results.to_csv("data/snitz-mordred.csv")
 
 results.shape
+

--- a/notebooks/generate-mordred.py
+++ b/notebooks/generate-mordred.py
@@ -18,7 +18,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem, SaltRemover, rdmolfiles
 from mordred import Calculator, descriptors as all_descriptors
 
-smiles = pd.read_csv('data/snitz-odorant-info.csv').set_index('CID')['IsomericSMILES']
+smiles = pd.read_csv("data/snitz-odorant-info.csv").set_index("CID")["IsomericSMILES"]
 
 calc = Calculator(all_descriptors)
 print("Convering SMILES string to Mol format...")
@@ -29,14 +29,14 @@ for i, (cid, mol) in enumerate(mols.items()):
     if i > 0 and i % 100 == 0:
         print("Finished %d" % i)
     try:
-        mol.SetProp("_Name","%d: %s" % (cid, smiles[cid]))
-        mol = s.StripMol(mol,dontRemoveEverything=True)
+        mol.SetProp("_Name", "%d: %s" % (cid, smiles[cid]))
+        mol = s.StripMol(mol, dontRemoveEverything=True)
         mol = Chem.AddHs(mol)
         AllChem.Compute2DCoords(mol)
         AllChem.EmbedMolecule(mol)
-        AllChem.UFFOptimizeMolecule(mol) # Is this deterministic?  
+        AllChem.UFFOptimizeMolecule(mol)  # Is this deterministic?
     except Exception as e:
-        print('Exception for %d' % cid)
+        print("Exception for %d" % cid)
         mols[cid] = None
     else:
         mols[cid] = mol
@@ -45,7 +45,7 @@ mols = {cid: mol for cid, mol in mols.items() if mol}
 len(set(smiles.index))
 
 results = calc.pandas(mols.values())
-results = results.set_index(pd.Index(mols.keys(), name='CID'))
+results = results.set_index(pd.Index(mols.keys(), name="CID"))
 results.head()
 
 results.shape
@@ -59,17 +59,19 @@ def fix(x):
         x = None
     return x
 
+
 results = results.applymap(fix)
 # -
 
 frac_bad = results.isnull().mean()
-good = frac_bad[frac_bad<0.3].index
+good = frac_bad[frac_bad < 0.3].index
 results = results.loc[:, good]
 
 from fancyimpute import KNN
+
 knn = KNN(k=5)
 results[:] = knn.fit_transform(results.values)
 
-results.to_csv('data/snitz-mordred.csv')
+results.to_csv("data/snitz-mordred.csv")
 
 results.shape

--- a/notebooks/generate-mordred.py
+++ b/notebooks/generate-mordred.py
@@ -14,11 +14,11 @@
 # ---
 
 import pandas as pd
+from fancyimpute import KNN
 from mordred import Calculator
 from mordred import descriptors as all_descriptors
 from rdkit import Chem
 from rdkit.Chem import AllChem, SaltRemover
-from fancyimpute import KNN
 
 smiles = pd.read_csv("data/snitz-odorant-info.csv").set_index("CID")["IsomericSMILES"]
 
@@ -37,7 +37,7 @@ for i, (cid, mol) in enumerate(mols.items()):
         AllChem.Compute2DCoords(mol)
         AllChem.EmbedMolecule(mol)
         AllChem.UFFOptimizeMolecule(mol)  # Is this deterministic?
-    except Exception as e:
+    except Exception:
         print("Exception for %d" % cid)
         mols[cid] = None
     else:
@@ -52,12 +52,14 @@ results.head()
 
 results.shape
 
+
 def fix(x):
     try:
         x = float(x)
     except Exception:
         x = None
     return x
+
 
 results = results.applymap(fix)
 
@@ -71,4 +73,3 @@ results[:] = knn.fit_transform(results.values)
 results.to_csv("data/snitz-mordred.csv")
 
 results.shape
-

--- a/notebooks/generate-mordred.py
+++ b/notebooks/generate-mordred.py
@@ -14,9 +14,10 @@
 # ---
 
 import pandas as pd
+from mordred import Calculator
+from mordred import descriptors as all_descriptors
 from rdkit import Chem
 from rdkit.Chem import AllChem, SaltRemover, rdmolfiles
-from mordred import Calculator, descriptors as all_descriptors
 
 smiles = pd.read_csv("data/snitz-odorant-info.csv").set_index("CID")["IsomericSMILES"]
 

--- a/notebooks/get-good-scents.py
+++ b/notebooks/get-good-scents.py
@@ -14,10 +14,11 @@
 # ---
 
 import re
-import requests
 from urllib.request import quote
-import pandas as pd
+
 import bs4
+import pandas as pd
+import requests
 
 
 # +

--- a/notebooks/get-good-scents.py
+++ b/notebooks/get-good-scents.py
@@ -13,11 +13,7 @@
 #     name: python3
 # ---
 
-import re
-from urllib.request import quote
-
 import bs4
-import pandas as pd
 import requests
 
 

--- a/notebooks/get-good-scents.py
+++ b/notebooks/get-good-scents.py
@@ -24,23 +24,24 @@ import bs4
 def name2soup(name):
     base_url = "http://www.thegoodscentscompany.com"
     url = "%s/search3.php" % base_url
-    data = {'qName': name, 'submit.x': 0, 'submit.y': 0}
+    data = {"qName": name, "submit.x": 0, "submit.y": 0}
     response = requests.post(url, data)
-    index = response.text.find('data/')
+    index = response.text.find("data/")
     soup = None
     if index > 0:
-        path = response.text[index:(index+25)].split("'")[0]
-        url = "%s/%s" % (base_url,path)
+        path = response.text[index : (index + 25)].split("'")[0]
+        url = "%s/%s" % (base_url, path)
         response = requests.get(url)
         soup = bs4.BeautifulSoup(response.text)
     return soup
+
 
 def soup2odor(soup):
     chem_tables = soup.find_all("table", {"class": "cheminfo"})
     odor = None
     for t in chem_tables:
-        if 'Odor' in t.text:
-            odor = [x.text for x in t.find_all('td')]
+        if "Odor" in t.text:
+            odor = [x.text for x in t.find_all("td")]
             break
     return odor
 
@@ -52,6 +53,6 @@ odors = soup2odor(soup)
 # -
 
 for odor in odors:
-    if 'Odor Strength' in odor:
-        strength = odor.split(':')[1].split(',')[0].strip()
+    if "Odor Strength" in odor:
+        strength = odor.split(":")[1].split(",")[0].strip()
         print(strength)

--- a/notebooks/good-scents-scrape.py
+++ b/notebooks/good-scents-scrape.py
@@ -96,7 +96,7 @@ for i, s in enumerate(cas_cid_smiles["SMILES"]):
     if not any([x in s for x in ["@", "@@", "/", "\\"]]):
         print(
             "This SMILES string has no stereomeric information: CAS=%s; CID=%d; SMILES=%s"
-            % (cas_cid_smiles["Type"][i], cas_cid_smiles.index[i], cas_cid_smiles["CID"][i], s)
+            % (cas_cid_smiles["Type"][i], cas_cid_smiles.index[i], cas_cid_smiles["CID"][i])
         )
 
 pairs = cas_cid_smiles[cas_cid_smiles["Enantiomer"] != ""]

--- a/notebooks/good-scents-scrape.py
+++ b/notebooks/good-scents-scrape.py
@@ -14,10 +14,11 @@
 # ---
 
 import re
-import requests
 from urllib.request import quote
-import pandas as pd
+
 import bs4
+import pandas as pd
+import requests
 
 df = pd.read_excel("data/vcd_database.xlsx")
 

--- a/notebooks/good-scents-scrape.py
+++ b/notebooks/good-scents-scrape.py
@@ -19,55 +19,68 @@ from urllib.request import quote
 import pandas as pd
 import bs4
 
-df = pd.read_excel('data/vcd_database.xlsx')
+df = pd.read_excel("data/vcd_database.xlsx")
 
-cas_list = set(list(df.iloc[:,6].replace(0,None).dropna())[1:])
+cas_list = set(list(df.iloc[:, 6].replace(0, None).dropna())[1:])
 print(len(cas_list))
 
-cas_cid_smiles = pd.DataFrame(columns=['CID', 'SMILES'])
+cas_cid_smiles = pd.DataFrame(columns=["CID", "SMILES"])
 for cas in list(cas_list):
-    url = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/%s/property/isomericSMILES/JSON" % cas
+    url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/%s/property/isomericSMILES/JSON"
+        % cas
+    )
     r = requests.get(url)
     if r.status_code == 200:
-        xs = r.json()['PropertyTable']['Properties']
+        xs = r.json()["PropertyTable"]["Properties"]
         found_chiral_smiles = False
         for x in xs:
-            if any([char in x['IsomericSMILES'] for char in ['@','@@','/','\\']]): # Is chiral
-                cas_cid_smiles.loc[cas] = [x['CID'], x['IsomericSMILES']]
+            if any([char in x["IsomericSMILES"] for char in ["@", "@@", "/", "\\"]]):  # Is chiral
+                cas_cid_smiles.loc[cas] = [x["CID"], x["IsomericSMILES"]]
                 found_chiral_smiles = True
                 break
         if not found_chiral_smiles:
             print("No chiral SMILES found for CAS %s" % cas)
     else:
         print("No result for CAS %s" % cas)
-cas_cid_smiles['Type'] = 'Original'
-cas_cid_smiles['Enantiomer'] = ''
+cas_cid_smiles["Type"] = "Original"
+cas_cid_smiles["Enantiomer"] = ""
 print(cas_cid_smiles.shape[0])
 
-original_smiles_list = list(cas_cid_smiles['SMILES'])
+original_smiles_list = list(cas_cid_smiles["SMILES"])
 original_cas_list = list(cas_cid_smiles.index)
-for i,smiles in enumerate(original_smiles_list):
-    smiles_m = smiles.replace('@@','a').replace('@','b').replace('/','c').replace('\\','d')\
-                     .replace('a','@').replace('b','@@').replace('c','\\').replace('d','/')             
-    url = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/%s/synonyms/JSON" % quote(smiles_m)  
+for i, smiles in enumerate(original_smiles_list):
+    smiles_m = (
+        smiles.replace("@@", "a")
+        .replace("@", "b")
+        .replace("/", "c")
+        .replace("\\", "d")
+        .replace("a", "@")
+        .replace("b", "@@")
+        .replace("c", "\\")
+        .replace("d", "/")
+    )
+    url = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/%s/synonyms/JSON" % quote(
+        smiles_m
+    )
     r = requests.get(url)
     if r.status_code == 200:
-        x = r.json()['InformationList']['Information'][0]
-        CID = x['CID']
+        x = r.json()["InformationList"]["Information"][0]
+        CID = x["CID"]
         found_cas = False
-        for synonym in x['Synonym']:
-            if re.match('[0-9]+-[0-9]+-[0-9]+', synonym) and ' ' not in synonym:
+        for synonym in x["Synonym"]:
+            if re.match("[0-9]+-[0-9]+-[0-9]+", synonym) and " " not in synonym:
                 found_cas = True
                 cas = synonym
                 original_cas = cas_cid_smiles.index[i]
                 if cas == original_cas:
-                    print('Rejected identical CAS %s' % cas)
+                    print("Rejected identical CAS %s" % cas)
                     continue
                 if cas in original_cas_list:
-                    print('Already have data on CAS %s' % cas)
+                    print("Already have data on CAS %s" % cas)
                     continue
-                cas_cid_smiles.loc[cas] = [x['CID'], smiles_m, 'Mirrored', original_cas]
-                cas_cid_smiles.loc[original_cas, 'Enantiomer'] = cas
+                cas_cid_smiles.loc[cas] = [x["CID"], smiles_m, "Mirrored", original_cas]
+                cas_cid_smiles.loc[original_cas, "Enantiomer"] = cas
                 break
         if not found_cas:
             print("No CAS found for mirror SMILES %s" % smiles_m)
@@ -75,40 +88,47 @@ for i,smiles in enumerate(original_smiles_list):
         print("No result for mirror SMILES string %s" % smiles_m)
 print(cas_cid_smiles.shape[0])
 
-cas_cid_smiles['Type'].value_counts()
+cas_cid_smiles["Type"].value_counts()
 
 # This should print nothing if all the SMILES strings have stereometic information
-for i,s in enumerate(cas_cid_smiles['SMILES']):
-    if not any([x in s for x in ['@','@@','/','\\']]):
-        print('This SMILES string has no stereomeric information: CAS=%s; CID=%d; SMILES=%s' % (cas_cid_smiles['Type'][i],cas_cid_smiles.index[i],cas_cid_smiles['CID'][i],s))
+for i, s in enumerate(cas_cid_smiles["SMILES"]):
+    if not any([x in s for x in ["@", "@@", "/", "\\"]]):
+        print(
+            "This SMILES string has no stereomeric information: CAS=%s; CID=%d; SMILES=%s"
+            % (cas_cid_smiles["Type"][i], cas_cid_smiles.index[i], cas_cid_smiles["CID"][i], s)
+        )
 
-pairs = cas_cid_smiles[cas_cid_smiles['Enantiomer'] != '']
-print("There are %d pairs of enantiomers for which we have VCD spectra for at least one member of the pair." % (len(pairs)/2))
+pairs = cas_cid_smiles[cas_cid_smiles["Enantiomer"] != ""]
+print(
+    "There are %d pairs of enantiomers for which we have VCD spectra for at least one member of the pair."
+    % (len(pairs) / 2)
+)
 
 pairs
 
 
 def cas2soup(cas):
     import requests
+
     base_url = "http://www.thegoodscentscompany.com"
-    url = "%s/search3.php?qName=%s&submit.x=0&submit.y=0" % (base_url,cas)
+    url = "%s/search3.php?qName=%s&submit.x=0&submit.y=0" % (base_url, cas)
     response = requests.get(url)
-    index = response.text.find('data/')
+    index = response.text.find("data/")
     soup = None
     if index > 0:
-        path = response.text[index:(index+25)].split("'")[0]
-        url = "%s/%s" % (base_url,path)
+        path = response.text[index : (index + 25)].split("'")[0]
+        url = "%s/%s" % (base_url, path)
         response = requests.get(url)
         soup = bs4.BeautifulSoup(response.text)
     return soup
 
 
 def soup2odor(soup):
-    chem_tables = soup.find_all("table",{"class":"cheminfo"})
+    chem_tables = soup.find_all("table", {"class": "cheminfo"})
     odor = None
     for t in chem_tables:
-        if 'Odor' in t.text:
-            odor = [x.text for x in t.find_all('td')]
+        if "Odor" in t.text:
+            odor = [x.text for x in t.find_all("td")]
             break
     return odor
 
@@ -123,24 +143,26 @@ for cas in cas_cid_smiles.index:
             print("Found odor info for %s" % cas)
             cas_odors[cas] = odor
 
-print("We have GoodScents odors information for %d molecules in the enantiomer set" % len(cas_odors))
+print(
+    "We have GoodScents odors information for %d molecules in the enantiomer set" % len(cas_odors)
+)
 
 x = cas_cid_smiles.copy()
-x['Odor'] = 0
+x["Odor"] = 0
 for cas in cas_odors:
-    x.loc[cas,'Odor'] = 1
-x2 = x[(x['Odor']==1) & (x['Enantiomer'] != '')]
-x3 = x2[x2['Enantiomer'].isin(list(x2.index))]
-print("We have odor info and spectra for %d enantiomers (%d pairs)" % (len(x3), len(x3)/2))
+    x.loc[cas, "Odor"] = 1
+x2 = x[(x["Odor"] == 1) & (x["Enantiomer"] != "")]
+x3 = x2[x2["Enantiomer"].isin(list(x2.index))]
+print("We have odor info and spectra for %d enantiomers (%d pairs)" % (len(x3), len(x3) / 2))
 
 x3.shape
 
-x3['Strength'] = ''
+x3["Strength"] = ""
 for cas, odor in cas_odors.items():
     for o in odor:
-        if 'Odor Strength' in o:
-            strength = o.split(':')[1].split(',')[0].strip()
+        if "Odor Strength" in o:
+            strength = o.split(":")[1].split(",")[0].strip()
             if cas in x3.index:
-                x3.loc[cas, 'Strength'] = strength
+                x3.loc[cas, "Strength"] = strength
 
 x3

--- a/notebooks/goodscents-arctander.py
+++ b/notebooks/goodscents-arctander.py
@@ -16,7 +16,9 @@
 # #### Basically, I just started from the mergedOdorants file that Joel sent me, and converted SMILES strings to CIDs
 
 import os
+
 import pandas as pd
+
 import pyrfume
 from pyrfume import odorants
 

--- a/notebooks/goodscents-arctander.py
+++ b/notebooks/goodscents-arctander.py
@@ -20,20 +20,20 @@ import pandas as pd
 import pyrfume
 from pyrfume import odorants
 
-file_path = os.path.join(pyrfume.DATA, 'mergedOdorants.csv')
+file_path = os.path.join(pyrfume.DATA, "mergedOdorants.csv")
 df = pd.read_csv(file_path, index_col=0)
 
 # Get CIDs from PubChem
-smiles_cids = odorants.get_cids(df['NAME'], kind='smiles')
+smiles_cids = odorants.get_cids(df["NAME"], kind="smiles")
 
 # Merge back into this list
-df = pd.Series(smiles_cids, name='PubChemID').to_frame().join(df.set_index('NAME'))
+df = pd.Series(smiles_cids, name="PubChemID").to_frame().join(df.set_index("NAME"))
 
 # Save back to a file of just CIDs
-for lib, name in [('goodscent', 'goodscents'), ('arc', 'arctander')]:
-    file_path = os.path.join(pyrfume.DATA, '%s_cids.txt' % name)
-    cids = sorted(set(df[df['lib']==lib]['PubChemID']) - {0})
-    pd.Series(cids, name='CID').to_csv(file_path, header=True, index=False)
+for lib, name in [("goodscent", "goodscents"), ("arc", "arctander")]:
+    file_path = os.path.join(pyrfume.DATA, "%s_cids.txt" % name)
+    cids = sorted(set(df[df["lib"] == lib]["PubChemID"]) - {0})
+    pd.Series(cids, name="CID").to_csv(file_path, header=True, index=False)
 
-file_path = os.path.join(pyrfume.DATA, 'mergedOdorants_with_cids.csv')
+file_path = os.path.join(pyrfume.DATA, "mergedOdorants_with_cids.csv")
 df.to_csv(file_path)

--- a/notebooks/kekule-js.py
+++ b/notebooks/kekule-js.py
@@ -18,18 +18,19 @@ from IPython.display import display, Javascript, HTML
 # Load the Kekule JS file and CSS style
 # These can be downloaded from:
 # http://partridgejiang.github.io/Kekule.js/download/files/kekule.js.zip
-Javascript(filename='kekule/kekule.min.js',
-           css='kekule/themes/default/kekule.css')
+Javascript(filename="kekule/kekule.min.js", css="kekule/themes/default/kekule.css")
 
 # Make sure the mol file we want to show exists
 import os
-assert os.path.isfile('../data/random.mol')
+
+assert os.path.isfile("../data/random.mol")
 
 # Create a canvas on which to show the molecule
 HTML('<div id="div1"></div>')
 
 # Show the molecule
-Javascript("""
+Javascript(
+    """
 // read the file
 fetch('../data/random.mol')
   .then(function(response) {
@@ -45,4 +46,5 @@ fetch('../data/random.mol')
     // Put the molecule in the viewer
     chemViewer.setChemObj(mol);
   });
-""")
+"""
+)

--- a/notebooks/kekule-js.py
+++ b/notebooks/kekule-js.py
@@ -13,7 +13,8 @@
 #     name: python3
 # ---
 
-from IPython.display import HTML, Javascript, display
+from IPython.display import HTML, Javascript
+import os
 
 # Load the Kekule JS file and CSS style
 # These can be downloaded from:
@@ -21,8 +22,6 @@ from IPython.display import HTML, Javascript, display
 Javascript(filename="kekule/kekule.min.js", css="kekule/themes/default/kekule.css")
 
 # Make sure the mol file we want to show exists
-import os
-
 assert os.path.isfile("../data/random.mol")
 
 # Create a canvas on which to show the molecule

--- a/notebooks/kekule-js.py
+++ b/notebooks/kekule-js.py
@@ -13,8 +13,9 @@
 #     name: python3
 # ---
 
-from IPython.display import HTML, Javascript
 import os
+
+from IPython.display import HTML, Javascript
 
 # Load the Kekule JS file and CSS style
 # These can be downloaded from:

--- a/notebooks/kekule-js.py
+++ b/notebooks/kekule-js.py
@@ -13,7 +13,7 @@
 #     name: python3
 # ---
 
-from IPython.display import display, Javascript, HTML
+from IPython.display import HTML, Javascript, display
 
 # Load the Kekule JS file and CSS style
 # These can be downloaded from:

--- a/notebooks/keller-2016.py
+++ b/notebooks/keller-2016.py
@@ -16,16 +16,18 @@
 import pyrfume
 from pyrfume import keller
 
-raw = keller.load_raw_bmc_data(only_dream_subjects=False,  # Whether to only keep DREAM subjects
-                               only_dream_descriptors=False,  # Whether to only keep DREAM descriptors
-                               only_dream_molecules=False)  # Whether to only keep DREAM molecules)
+raw = keller.load_raw_bmc_data(
+    only_dream_subjects=False,  # Whether to only keep DREAM subjects
+    only_dream_descriptors=False,  # Whether to only keep DREAM descriptors
+    only_dream_molecules=False,
+)  # Whether to only keep DREAM molecules)
 raw.head()
 
 cooked = keller.format_bmc_data(raw)
 cooked.head()
 
-cooked.index = cooked.index.reorder_levels([1, 0, 2, 3]) # Put CID first
+cooked.index = cooked.index.reorder_levels([1, 0, 2, 3])  # Put CID first
 
-cooked = cooked.sort_index(level=0) # Sort by CID ascending
+cooked = cooked.sort_index(level=0)  # Sort by CID ascending
 
-pyrfume.save_data(cooked, 'keller_2016/data.csv')
+pyrfume.save_data(cooked, "keller_2016/data.csv")

--- a/notebooks/leon-map.py
+++ b/notebooks/leon-map.py
@@ -22,30 +22,48 @@ import matplotlib.pyplot as plt
 
 # ## Load and plot Decanal
 
-plt.figure(figsize=(4.5,6))
+plt.figure(figsize=(4.5, 6))
 ax = plt.gca()
-df = pd.read_csv('data/MamloukCSV3/decanal_SG3.csv',header=1).astype(float).replace(-100.0,np.nan)
+df = pd.read_csv("data/MamloukCSV3/decanal_SG3.csv", header=1).astype(float).replace(-100.0, np.nan)
 df.columns = range(df.shape[1])
-sns.heatmap(df,ax=ax,cmap='RdBu_r',vmin=-5,vmax=5,cbar_kws={'label':'Z-score'},xticklabels='',yticklabels='')
+sns.heatmap(
+    df,
+    ax=ax,
+    cmap="RdBu_r",
+    vmin=-5,
+    vmax=5,
+    cbar_kws={"label": "Z-score"},
+    xticklabels="",
+    yticklabels="",
+)
 
-print("There are %d total maps" % len(os.listdir('data/MamloukCSV3')))
+print("There are %d total maps" % len(os.listdir("data/MamloukCSV3")))
 
 # ## Load and plot the first 25 maps
 
-fig,axes = plt.subplots(5,5,figsize=(12,16))
-path = 'data/MamloukCSV3'
-for i,file in enumerate(os.listdir(path)[:25]):
+fig, axes = plt.subplots(5, 5, figsize=(12, 16))
+path = "data/MamloukCSV3"
+for i, file in enumerate(os.listdir(path)[:25]):
     ax = axes.flat[i]
-    file = os.path.join(path,file)
+    file = os.path.join(path, file)
     try:
-        df = pd.read_csv(file,header=1)
+        df = pd.read_csv(file, header=1)
         molecule = df.columns[0]
-        df = df.astype(float).replace(-100.0,np.nan)
+        df = df.astype(float).replace(-100.0, np.nan)
     except ValueError:
-        df = pd.read_csv(file,header=2).astype(float).replace(-100.0,np.nan)
-        molecule = '%s\n(%s)' % (molecule,df.columns[0].strip())
+        df = pd.read_csv(file, header=2).astype(float).replace(-100.0, np.nan)
+        molecule = "%s\n(%s)" % (molecule, df.columns[0].strip())
     df.columns = range(df.shape[1])
-    sns.heatmap(df,ax=ax,cmap='RdBu_r',vmin=-5,vmax=5,cbar=None,
-                cbar_kws={'label':'Z-score'},xticklabels='',yticklabels='')
+    sns.heatmap(
+        df,
+        ax=ax,
+        cmap="RdBu_r",
+        vmin=-5,
+        vmax=5,
+        cbar=None,
+        cbar_kws={"label": "Z-score"},
+        xticklabels="",
+        yticklabels="",
+    )
     ax.set_title(molecule)
 plt.tight_layout()

--- a/notebooks/leon-map.py
+++ b/notebooks/leon-map.py
@@ -15,10 +15,11 @@
 
 # %matplotlib inline
 import os
-import seaborn as sns
-import pandas as pd
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 
 # ## Load and plot Decanal
 

--- a/notebooks/leon.py
+++ b/notebooks/leon.py
@@ -20,46 +20,61 @@ import rdkit
 from rdkit import Chem
 import re
 
-re.sub('l-(?![0-9])', 'l ', 'amyl-2-acetate')
+re.sub("l-(?![0-9])", "l ", "amyl-2-acetate")
 
 from pathlib import Path
+
 p = Path(pyrfume.DATA)
 old_names = []
 new_names = []
-for file in (p / 'leon' / '3D_mol_files').glob('*.mol'):
-    name = file.name.replace('.mol', '')
+for file in (p / "leon" / "3D_mol_files").glob("*.mol"):
+    name = file.name.replace(".mol", "")
     old_names.append(name)
     # Replace underscore with hyphen
-    name = name.replace('_','-')
-    # Remove extraneous hyphens 
-    name = re.sub('(?<![0-9\(])-(?![0-9])', ' ', name)
+    name = name.replace("_", "-")
+    # Remove extraneous hyphens
+    name = re.sub("(?<![0-9\(])-(?![0-9])", " ", name)
     # Add back hyphens after prefixes
-    for x in ['alpha', 'beta', 'gamma', 'delta', 'tert', 'L', 'D', 'm', 'o', 'p', 'cis', 'trans', 'sec']:
-        name = name.replace('%s '%x, '%s-'%x)
+    for x in [
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "tert",
+        "L",
+        "D",
+        "m",
+        "o",
+        "p",
+        "cis",
+        "trans",
+        "sec",
+    ]:
+        name = name.replace("%s " % x, "%s-" % x)
     # Move isomeric identifiers to the front of the name
-    for x in ['(-)', '(+)']:
+    for x in ["(-)", "(+)"]:
         if x in name:
-            name = '%s-%s' % (x, name.replace(x, ''))
+            name = "%s-%s" % (x, name.replace(x, ""))
     new_names.append(name)
-    #print(name)
+    # print(name)
 
 cids = get_cids(new_names)
 
-df = pd.Series(cids, name='CID').to_frame()
-df['Old Name'] = old_names
-df.index.name = 'Name'
+df = pd.Series(cids, name="CID").to_frame()
+df["Old Name"] = old_names
+df.index.name = "Name"
 df = df.reset_index()
 df.head()
 
-df[df['CID']==0]
+df[df["CID"] == 0]
 
-df.loc[67, 'CID'] = 19309
-df.loc[76, 'CID'] = 11160 
-df.loc[79, 'CID'] = 8092 
-df.loc[155, 'CID'] = 28500  
-df.loc[170, 'CID'] = 251531
+df.loc[67, "CID"] = 19309
+df.loc[76, "CID"] = 11160
+df.loc[79, "CID"] = 8092
+df.loc[155, "CID"] = 28500
+df.loc[170, "CID"] = 251531
 
-df = df.set_index('CID').sort_index()
+df = df.set_index("CID").sort_index()
 df.head()
 
-df.to_csv(p / 'leon' / 'leon_cids.csv', sep='\t')
+df.to_csv(p / "leon" / "leon_cids.csv", sep="\t")

--- a/notebooks/leon.py
+++ b/notebooks/leon.py
@@ -16,15 +16,12 @@
 import re
 
 import pandas as pd
-import rdkit
-from rdkit import Chem
 
 import pyrfume
 from pyrfume.odorants import get_cids
+from pathlib import Path
 
 re.sub("l-(?![0-9])", "l ", "amyl-2-acetate")
-
-from pathlib import Path
 
 p = Path(pyrfume.DATA)
 old_names = []
@@ -35,7 +32,7 @@ for file in (p / "leon" / "3D_mol_files").glob("*.mol"):
     # Replace underscore with hyphen
     name = name.replace("_", "-")
     # Remove extraneous hyphens
-    name = re.sub("(?<![0-9\(])-(?![0-9])", " ", name)
+    name = re.sub(r"(?<![0-9\(])-(?![0-9])", " ", name)
     # Add back hyphens after prefixes
     for x in [
         "alpha",

--- a/notebooks/leon.py
+++ b/notebooks/leon.py
@@ -14,12 +14,12 @@
 # ---
 
 import re
+from pathlib import Path
 
 import pandas as pd
 
 import pyrfume
 from pyrfume.odorants import get_cids
-from pathlib import Path
 
 re.sub("l-(?![0-9])", "l ", "amyl-2-acetate")
 

--- a/notebooks/leon.py
+++ b/notebooks/leon.py
@@ -13,12 +13,14 @@
 #     name: python3
 # ---
 
+import re
+
 import pandas as pd
-import pyrfume
-from pyrfume.odorants import get_cids
 import rdkit
 from rdkit import Chem
-import re
+
+import pyrfume
+from pyrfume.odorants import get_cids
 
 re.sub("l-(?![0-9])", "l ", "amyl-2-acetate")
 

--- a/notebooks/make-solutions.py
+++ b/notebooks/make-solutions.py
@@ -17,8 +17,9 @@
 # %autoreload 2
 # #%load_ext line_profiler
 
-from pyrfume.odorants import Solution, Compound, ChemicalOrder, Vendor, Molecule
 import quantities as pq
+
+from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Solution, Vendor
 
 # +
 # Instantiate two molecules by CID number

--- a/notebooks/make-solutions.py
+++ b/notebooks/make-solutions.py
@@ -17,8 +17,7 @@
 # %autoreload 2
 # #%load_ext line_profiler
 
-from pyrfume.odorants import Solution, Compound, ChemicalOrder, \
-                                  Vendor, Molecule
+from pyrfume.odorants import Solution, Compound, ChemicalOrder, Vendor, Molecule
 import quantities as pq
 
 # +
@@ -29,16 +28,16 @@ l_limonene = Molecule(439250, fill=True)  # Orange smell (check)
 light_mineral_oil = Molecule(347911206, fill=True)  # An odorless solvent
 
 # Vapor pressures at 25 degrees Celsius (obtained from PubChem)
-beta_pinene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
-d_limonene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
-l_limonene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
+beta_pinene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
+d_limonene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
+l_limonene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
 light_mineral_oil.vapor_pressure = 0 * pq.mmHg  # Actually .0001 * pq.hPa
 
 # Densities at 20 degrees Celsius (obtained from PubChem)
-beta_pinene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-d_limonene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-l_limonene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-light_mineral_oil.density = 0.85 * pq.g/pq.cc # Made up, fill with real values
+beta_pinene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+d_limonene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+l_limonene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+light_mineral_oil.density = 0.85 * pq.g / pq.cc  # Made up, fill with real values
 
 # Mineral oil does not have a proper molecular weight since
 # it is itself a mixture, but we have to put something reasonable
@@ -47,16 +46,18 @@ light_mineral_oil.molecular_weight = 500 * pq.g / pq.mol
 
 # +
 # Create a vendor
-sigma_aldrich = Vendor('Sigma Aldrich', 'http://www.sigma.com')
+sigma_aldrich = Vendor("Sigma Aldrich", "http://www.sigma.com")
 
 # Specify two chemicals ordered from this vendor,
 # which are nominally the above molecules
-solvent_order = ChemicalOrder(light_mineral_oil, sigma_aldrich, '')
-#chemical_orders = [ChemicalOrder(hexanal, sigma_aldrich, ''),
+solvent_order = ChemicalOrder(light_mineral_oil, sigma_aldrich, "")
+# chemical_orders = [ChemicalOrder(hexanal, sigma_aldrich, ''),
 #                   ChemicalOrder(isoamyl_acetate, sigma_aldrich, '')]
-chemical_orders = [ChemicalOrder(beta_pinene, sigma_aldrich, ''),
-                   ChemicalOrder(d_limonene, sigma_aldrich, ''),
-                   ChemicalOrder(l_limonene, sigma_aldrich, '')]
+chemical_orders = [
+    ChemicalOrder(beta_pinene, sigma_aldrich, ""),
+    ChemicalOrder(d_limonene, sigma_aldrich, ""),
+    ChemicalOrder(l_limonene, sigma_aldrich, ""),
+]
 
 # These are now actual chemical on the shelf, with potential stock numbers
 # dates arrived, dates opened.
@@ -67,16 +68,10 @@ n_odorants = len(compounds)
 # Two odorants stocks that we produced by diluting the compounds above
 # TODO: An optimizer to determine what these solutions should be
 solutions = []
-solutions.append(Solution({compounds[0]: 1 * pq.mL,
-                           solvent: 24 * pq.mL}))
-solutions.append(Solution({compounds[1]: 1 * pq.mL,
-                           solvent: 24 * pq.mL}))
-solutions.append(Solution({compounds[2]: 1 * pq.mL,
-                           solvent: 24 * pq.mL}))
-solutions.append(Solution({compounds[0]: 0.01 * pq.mL,
-                           solvent: 24 * pq.mL}))
-solutions.append(Solution({compounds[1]: 0.01 * pq.mL,
-                           solvent: 24.9 * pq.mL}))
-solutions.append(Solution({compounds[2]: 0.01 * pq.mL,
-                           solvent: 24.9 * pq.mL}))
+solutions.append(Solution({compounds[0]: 1 * pq.mL, solvent: 24 * pq.mL}))
+solutions.append(Solution({compounds[1]: 1 * pq.mL, solvent: 24 * pq.mL}))
+solutions.append(Solution({compounds[2]: 1 * pq.mL, solvent: 24 * pq.mL}))
+solutions.append(Solution({compounds[0]: 0.01 * pq.mL, solvent: 24 * pq.mL}))
+solutions.append(Solution({compounds[1]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
+solutions.append(Solution({compounds[2]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
 n_solutions = len(solutions)

--- a/notebooks/odorant-optimization-demo.py
+++ b/notebooks/odorant-optimization-demo.py
@@ -21,12 +21,14 @@
 # -
 
 from itertools import combinations
+
 import numpy as np
 import pandas as pd
-from pyrfume.cabinets import get_mainland
-from pyrfume.optimization import OdorantSetOptimizer, get_coverage, get_entropy, get_spacing
 from rdkit import Chem
 from rdkit.DataStructs import FingerprintSimilarity
+
+from pyrfume.cabinets import get_mainland
+from pyrfume.optimization import OdorantSetOptimizer, get_coverage, get_entropy, get_spacing
 
 # Get contents of Mainland cabinet (any dataframe could do)
 cabinet = get_mainland()

--- a/notebooks/odorant-optimization-demo.py
+++ b/notebooks/odorant-optimization-demo.py
@@ -28,7 +28,7 @@ from rdkit import Chem
 from rdkit.DataStructs import FingerprintSimilarity
 
 from pyrfume.cabinets import get_mainland
-from pyrfume.optimization import OdorantSetOptimizer, get_coverage, get_entropy, get_spacing
+from pyrfume.optimization import OdorantSetOptimizer
 
 # Get contents of Mainland cabinet (any dataframe could do)
 cabinet = get_mainland()

--- a/notebooks/odorant-optimization-demo.py
+++ b/notebooks/odorant-optimization-demo.py
@@ -16,7 +16,7 @@
 # +
 # Upgrade to latest version of Pyrfume
 # #!pip install --user -U git+https://github.com/pyrfume/pyrfume
-    
+
 # And be sure to have pyrfume/data/cabinets/mainland.csv in place
 # -
 
@@ -31,14 +31,14 @@ from rdkit.DataStructs import FingerprintSimilarity
 # Get contents of Mainland cabinet (any dataframe could do)
 cabinet = get_mainland()
 # Get rid of any molecules without a valid SMILES stting
-cabinet = cabinet.dropna(subset=['SMILES'])
+cabinet = cabinet.dropna(subset=["SMILES"])
 # rdkit can't make mol from this one so drop that, too
 cabinet = cabinet.drop(24766)
 cids = list(cabinet.index)
 cabinet.head()
 
 # Compute all fingerprints
-fps = cabinet['SMILES'].apply(Chem.MolFromSmiles).apply(Chem.RDKFingerprint)
+fps = cabinet["SMILES"].apply(Chem.MolFromSmiles).apply(Chem.RDKFingerprint)
 # And then Tanimot distances
 tanimoto = pd.DataFrame(index=cids, columns=cids)
 tanimoto[:] = [[FingerprintSimilarity(fp1, fp2) for fp1 in fps] for fp2 in fps]
@@ -55,13 +55,11 @@ def mean_dist(indices, sim):
 
 # Prettier printing
 np.set_printoptions(precision=2, suppress=True)
-# Some weight you can make up, each tuple is one weight under consideration.  
+# Some weight you can make up, each tuple is one weight under consideration.
 # Tuple item 1 is a cabinet dataframe column or a custom name
 # Tuple item 2 is an operation of a function name and args to that function
 # Tuple item 3 is the actual weight (make positive to maximize, negative to minimize)
-weights = [('$/mol', 'mean', -5),
-           ('MW', 'sum', 3),
-           ('Tanimoto', (mean_dist, tanimoto), 1)]
+weights = [("$/mol", "mean", -5), ("MW", "sum", 3), ("Tanimoto", (mean_dist, tanimoto), 1)]
 # How many items you want in your set, e.g. how many odorants should the result contain?
 n_desired = 25
 # Create the optimizer.
@@ -78,5 +76,3 @@ optimizer.plot_score_history()
 best = hof[0]
 # Show the first few items of this list, which is a subset of the original cabinet
 cabinet.iloc[list(best)].head()
-
-

--- a/notebooks/odorless-validation.py
+++ b/notebooks/odorless-validation.py
@@ -27,7 +27,7 @@ with open("pubchem_100000.json", "w") as f:
 
 df = pd.DataFrame(index=sorted(all_statements), columns=["Odor", "Odorless", "Statements"])
 df.index.name = "CID"
-for cid in sorted(all_statements):
+for cid in sorted(all_statements):  # noqa: C901 (too complex -- TODO)
     statements = all_statements[cid]
     odor = False
     odorless = False

--- a/notebooks/odorless-validation.py
+++ b/notebooks/odorless-validation.py
@@ -14,9 +14,11 @@
 # ---
 
 import json
-import pandas as pd
-import pyrfume
 import re
+
+import pandas as pd
+
+import pyrfume
 
 all_statements = pyrfume.load_data("pubchem_scrape_100000.pkl")
 

--- a/notebooks/odorless-validation.py
+++ b/notebooks/odorless-validation.py
@@ -22,8 +22,6 @@ import pyrfume
 
 all_statements = pyrfume.load_data("pubchem_scrape_100000.pkl")
 
-import json
-
 with open("pubchem_100000.json", "w") as f:
     json.dump(all_statements, f)
 

--- a/notebooks/odorless-validation.py
+++ b/notebooks/odorless-validation.py
@@ -18,53 +18,53 @@ import pandas as pd
 import pyrfume
 import re
 
-all_statements = pyrfume.load_data('pubchem_scrape_100000.pkl')
+all_statements = pyrfume.load_data("pubchem_scrape_100000.pkl")
 
 import json
-with open('pubchem_100000.json', 'w') as f:
+
+with open("pubchem_100000.json", "w") as f:
     json.dump(all_statements, f)
 
-df = pd.DataFrame(index=sorted(all_statements),
-                  columns=['Odor', 'Odorless', 'Statements'])
-df.index.name = 'CID'
+df = pd.DataFrame(index=sorted(all_statements), columns=["Odor", "Odorless", "Statements"])
+df.index.name = "CID"
 for cid in sorted(all_statements):
     statements = all_statements[cid]
     odor = False
     odorless = False
     for statement in statements:
         statement = statement.lower()
-        if re.findall('no odor', statement):
+        if re.findall("no odor", statement):
             odorless = True
-        elif re.findall('no odour', statement):
+        elif re.findall("no odour", statement):
             odorless = True
-        elif re.findall('no smell', statement):
+        elif re.findall("no smell", statement):
             odorless = True
-        elif re.findall('no fragrance', statement):
+        elif re.findall("no fragrance", statement):
             odorless = True
-        elif re.findall('odorless', statement):
+        elif re.findall("odorless", statement):
             odorless = True
-        elif re.findall('odourless', statement):
+        elif re.findall("odourless", statement):
             odorless = True
-        elif re.findall('odoratus', statement):
+        elif re.findall("odoratus", statement):
             pass
-        elif re.findall('sense of smell', statement):
+        elif re.findall("sense of smell", statement):
             odor = True
-        elif re.findall('odor', statement):
+        elif re.findall("odor", statement):
             odor = True
-        elif re.findall('odour', statement):
+        elif re.findall("odour", statement):
             odor = True
-        elif re.findall('smell', statement):
+        elif re.findall("smell", statement):
             odor = True
-        elif re.findall('fragrance', statement):
+        elif re.findall("fragrance", statement):
             odor = True
-        elif re.findall('aroma ', statement):
+        elif re.findall("aroma ", statement):
             odor = True
         else:
             pass
     if odor and odorless:
-        pass#print(statements)
+        pass  # print(statements)
     df.loc[cid, :] = [odor, odorless, statements]
 
 df.head()
 
-pyrfume.save_data(df, 'pubchem_scrape_100000.csv')
+pyrfume.save_data(df, "pubchem_scrape_100000.csv")

--- a/notebooks/odorless.py
+++ b/notebooks/odorless.py
@@ -15,6 +15,7 @@
 
 # +
 import pandas as pd
+
 import pyrfume
 
 # Read file sent by Emily Mayhew on Sept. 23, 2019

--- a/notebooks/odorless.py
+++ b/notebooks/odorless.py
@@ -18,12 +18,12 @@ import pandas as pd
 import pyrfume
 
 # Read file sent by Emily Mayhew on Sept. 23, 2019
-df = pd.read_csv('u19predictions.csv')
+df = pd.read_csv("u19predictions.csv")
 # -
 
-df['CID'] = df['SMILEstring'].apply(lambda x:x.split(': ')[0])
-df['SMILES'] = df['SMILEstring'].apply(lambda x:x.split(': ')[1])
-df['PredictedOdorless'] = df['Prediction']=='Odorless'
-predicted_odorless = df.set_index('CID')['PredictedOdorless']
+df["CID"] = df["SMILEstring"].apply(lambda x: x.split(": ")[0])
+df["SMILES"] = df["SMILEstring"].apply(lambda x: x.split(": ")[1])
+df["PredictedOdorless"] = df["Prediction"] == "Odorless"
+predicted_odorless = df.set_index("CID")["PredictedOdorless"]
 
-pyrfume.save_data(predicted_odorless.to_frame(), 'odorants/predicted_odorless.csv')
+pyrfume.save_data(predicted_odorless.to_frame(), "odorants/predicted_odorless.csv")

--- a/notebooks/open-source-dream.py
+++ b/notebooks/open-source-dream.py
@@ -33,10 +33,8 @@ from sklearn.multioutput import MultiOutputRegressor
 
 import pyrfume
 from pyrfume.features import smiles_to_mordred, smiles_to_morgan_sim
-from pyrfume.odorants import from_cids
-from pyrfume.predictions import load_dream_model, predict, smiles_to_features
-
 from pyrfume.odorants import all_smiles, from_cids
+from pyrfume.predictions import load_dream_model, predict, smiles_to_features
 
 # ### Load the perceptual data from Keller and Vosshall, 2016
 

--- a/notebooks/open-source-dream.py
+++ b/notebooks/open-source-dream.py
@@ -22,20 +22,20 @@
 
 import pickle
 
-import mordred
 import numpy as np
 import opc_python.utils.loading as dream_loading
 import pandas as pd
-import rdkit
 from missingpy import KNNImputer
-from rickpy import ProgressBar
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import make_scorer
-from sklearn.model_selection import cross_val_score, cross_validate
+from sklearn.model_selection import cross_validate
 from sklearn.multioutput import MultiOutputRegressor
 
 import pyrfume
-from pyrfume.features import smiles_to_mordred, smiles_to_morgan, smiles_to_morgan_sim
+from pyrfume.features import smiles_to_mordred, smiles_to_morgan_sim
+from pyrfume.odorants import from_cids
+from pyrfume.predictions import load_dream_model, predict, smiles_to_features
+
 from pyrfume.odorants import all_smiles, from_cids
 
 # ### Load the perceptual data from Keller and Vosshall, 2016
@@ -184,9 +184,6 @@ with open(path, "wb") as f:
     pickle.dump([mor, list(X), list(Y), imputer_knn], f)
 
 # ### Demonstration: using the fitted model (can be run independently if the above has been run at some point)
-
-from pyrfume.odorants import from_cids
-from pyrfume.predictions import load_dream_model, predict, smiles_to_features
 
 novel_cids = [14896, 228583]  # Beta-pinene and 2-Furylacetone
 novel_info = from_cids(novel_cids)

--- a/notebooks/open-source-dream.py
+++ b/notebooks/open-source-dream.py
@@ -20,21 +20,23 @@
 # %load_ext autoreload
 # %autoreload 2
 
-from missingpy import KNNImputer
-import mordred
-import opc_python.utils.loading as dream_loading
-import numpy as np
-import pandas as pd
 import pickle
-import pyrfume
-from pyrfume.odorants import from_cids, all_smiles
-from pyrfume.features import smiles_to_mordred, smiles_to_morgan, smiles_to_morgan_sim
-from rickpy import ProgressBar
+
+import mordred
+import numpy as np
+import opc_python.utils.loading as dream_loading
+import pandas as pd
 import rdkit
+from missingpy import KNNImputer
+from rickpy import ProgressBar
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import make_scorer
 from sklearn.model_selection import cross_val_score, cross_validate
 from sklearn.multioutput import MultiOutputRegressor
+
+import pyrfume
+from pyrfume.features import smiles_to_mordred, smiles_to_morgan, smiles_to_morgan_sim
+from pyrfume.odorants import all_smiles, from_cids
 
 # ### Load the perceptual data from Keller and Vosshall, 2016
 
@@ -184,7 +186,7 @@ with open(path, "wb") as f:
 # ### Demonstration: using the fitted model (can be run independently if the above has been run at some point)
 
 from pyrfume.odorants import from_cids
-from pyrfume.predictions import load_dream_model, smiles_to_features, predict
+from pyrfume.predictions import load_dream_model, predict, smiles_to_features
 
 novel_cids = [14896, 228583]  # Beta-pinene and 2-Furylacetone
 novel_info = from_cids(novel_cids)

--- a/notebooks/plotly-cabinet.py
+++ b/notebooks/plotly-cabinet.py
@@ -16,11 +16,11 @@
 # +
 # Needed for all table stuff
 import pandas as pd
+import plotly
 # Needed for all plotting
 import plotly.graph_objs as go
 # Needed for offline stuff in the notebook
 from plotly.offline import init_notebook_mode, iplot
-import plotly
 from plotly.plotly import plot
 
 init_notebook_mode()

--- a/notebooks/plotly-cabinet.py
+++ b/notebooks/plotly-cabinet.py
@@ -20,17 +20,15 @@ import pandas as pd
 import plotly.graph_objs as go
 # Needed for offline stuff in the notebook
 from plotly.offline import init_notebook_mode, iplot
+import plotly
+from plotly.plotly import plot
 
 init_notebook_mode()
 
 # Needed to make figures on the web
-import plotly
-
 plotly.tools.set_credentials_file(username="rgerkin", api_key="DdQKMmvH8CMKvgNpBccy")
 plotly.tools.set_config_file(world_readable=True, sharing="public")
-from plotly.plotly import plot
 
-# +
 # Load the data
 df = pd.read_csv("data/Mainland Odor Cabinet with CIDs.csv").groupby("CID").first()
 

--- a/notebooks/plotly-cabinet.py
+++ b/notebooks/plotly-cabinet.py
@@ -14,12 +14,9 @@
 # ---
 
 # +
-# Needed for all table stuff
 import pandas as pd
 import plotly
-# Needed for all plotting
 import plotly.graph_objs as go
-# Needed for offline stuff in the notebook
 from plotly.offline import init_notebook_mode, iplot
 from plotly.plotly import plot
 

--- a/notebooks/plotly-cabinet.py
+++ b/notebooks/plotly-cabinet.py
@@ -16,10 +16,8 @@
 # +
 # Needed for all table stuff
 import pandas as pd
-
 # Needed for all plotting
 import plotly.graph_objs as go
-
 # Needed for offline stuff in the notebook
 from plotly.offline import init_notebook_mode, iplot
 

--- a/notebooks/plotly-cabinet.py
+++ b/notebooks/plotly-cabinet.py
@@ -22,43 +22,42 @@ import plotly.graph_objs as go
 
 # Needed for offline stuff in the notebook
 from plotly.offline import init_notebook_mode, iplot
+
 init_notebook_mode()
 
 # Needed to make figures on the web
 import plotly
-plotly.tools.set_credentials_file(username='rgerkin', api_key='DdQKMmvH8CMKvgNpBccy')
-plotly.tools.set_config_file(world_readable=True,
-                             sharing='public')
+
+plotly.tools.set_credentials_file(username="rgerkin", api_key="DdQKMmvH8CMKvgNpBccy")
+plotly.tools.set_config_file(world_readable=True, sharing="public")
 from plotly.plotly import plot
 
 # +
 # Load the data
-df = pd.read_csv('data/Mainland Odor Cabinet with CIDs.csv').groupby('CID').first()
+df = pd.read_csv("data/Mainland Odor Cabinet with CIDs.csv").groupby("CID").first()
 
 # The scatter plots themselves
 data = [
     go.Scatter(
-                    x=df[df['SourcedFrom'] == i]['Price'],
-                    y=df[df['SourcedFrom'] == i]['MW'],
-                    text=df[df['SourcedFrom'] == i]['ChemicalName'],
-                    mode='markers',
-                    opacity=0.7,
-                    marker={
-                        'size': 15,
-                        'line': {'width': 0.5, 'color': 'white'}
-                    },
-                    name=i
-                ) for i in df['SourcedFrom'].unique()
+        x=df[df["SourcedFrom"] == i]["Price"],
+        y=df[df["SourcedFrom"] == i]["MW"],
+        text=df[df["SourcedFrom"] == i]["ChemicalName"],
+        mode="markers",
+        opacity=0.7,
+        marker={"size": 15, "line": {"width": 0.5, "color": "white"}},
+        name=i,
+    )
+    for i in df["SourcedFrom"].unique()
 ]
 
-# The axes, etc.  
+# The axes, etc.
 layout = go.Layout(
-                xaxis={'type': 'log', 'title': 'Price'},
-                yaxis={'type': 'log', 'title': 'Molecular Weight'},
-                margin={'l': 40, 'b': 40, 't': 10, 'r': 10},
-                legend={'x': 0, 'y': 1},
-                hovermode='closest'
-            )
+    xaxis={"type": "log", "title": "Price"},
+    yaxis={"type": "log", "title": "Molecular Weight"},
+    margin={"l": 40, "b": 40, "t": 10, "r": 10},
+    legend={"x": 0, "y": 1},
+    hovermode="closest",
+)
 # -
 
 # Make an interactive version in the notebook

--- a/notebooks/prestwick.py
+++ b/notebooks/prestwick.py
@@ -14,7 +14,9 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
 from pyrfume import odorants
 

--- a/notebooks/prestwick.py
+++ b/notebooks/prestwick.py
@@ -18,15 +18,15 @@ import pandas as pd
 import pyrfume
 from pyrfume import odorants
 
-file_path = os.path.join(pyrfume.DATA, 'PrestwickChemLib.smi')
-prestwick_data = pd.read_csv(file_path, header=None, sep='\t')[0]
+file_path = os.path.join(pyrfume.DATA, "PrestwickChemLib.smi")
+prestwick_data = pd.read_csv(file_path, header=None, sep="\t")[0]
 prestwick_data.head()
 
-results = odorants.get_cids(prestwick_data['SMILES'], kind='SMILES', verbose=False)
+results = odorants.get_cids(prestwick_data["SMILES"], kind="SMILES", verbose=False)
 
-prestwick_data = pd.Series(results, name='CID').to_frame().join(prestwick_data)[['CID']]
+prestwick_data = pd.Series(results, name="CID").to_frame().join(prestwick_data)[["CID"]]
 prestwick_data.head()
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = os.path.join(pyrfume.DATA, 'prestwick.csv')
+file_path = os.path.join(pyrfume.DATA, "prestwick.csv")
 prestwick_data.to_csv(file_path)

--- a/notebooks/pubchem-odor-info.py
+++ b/notebooks/pubchem-odor-info.py
@@ -17,11 +17,12 @@
 # %load_ext autoreload
 # %autoreload 2
 import re
+
+import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
-from rickpy import get_sheet, ProgressBar
 from olfactometer import odorants as o
+from rickpy import ProgressBar, get_sheet
 
 sns.set(font_scale=1.5)
 

--- a/notebooks/pubchem-odor-info.py
+++ b/notebooks/pubchem-odor-info.py
@@ -105,7 +105,7 @@ for i, cid in enumerate(x.index):
 # Parse this into boiling points in Celsius
 for cid, bp_raw in x["BP"].iteritems():
     if isinstance(bp_raw, str):  # math.isnan(bp_raw):
-        num = re.findall("[-+]?[0-9]*\.?[0-9]+", bp_raw)[0]
+        num = re.findall(r"[-+]?[0-9]*\.?[0-9]+", bp_raw)[0]
         units = None
         if any([s in bp_raw for s in ["° F", "°F", "deg F", "DEG F"]]):
             units = "F"

--- a/notebooks/pubchem-odor-info.py
+++ b/notebooks/pubchem-odor-info.py
@@ -22,9 +22,10 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 from rickpy import get_sheet, ProgressBar
 from olfactometer import odorants as o
+
 sns.set(font_scale=1.5)
 
-o.get_compound_odor(7945, raw=True);
+o.get_compound_odor(7945, raw=True)
 
 o.get_compound_odor(8093)
 
@@ -32,11 +33,15 @@ o.get_compound_odor(7945)
 
 # +
 # Two Google sheets of odor cabinet data
-smith_cabinet = get_sheet('1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc', 'smith-compounds').set_index('CID')
-gerkin_cabinet = get_sheet('1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc', 'gerkin-compounds').set_index('CID')
+smith_cabinet = get_sheet(
+    "1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc", "smith-compounds"
+).set_index("CID")
+gerkin_cabinet = get_sheet(
+    "1PlU4zHyRXtcI7Y-O6xYtlIyKoKk8hX1I9zfx8KFELdc", "gerkin-compounds"
+).set_index("CID")
 
 # Concatenate
-x = pd.concat([gerkin_cabinet[['ChemicalName']], smith_cabinet[['ChemicalName']]])
+x = pd.concat([gerkin_cabinet[["ChemicalName"]], smith_cabinet[["ChemicalName"]]])
 
 # Drop duplicate CIDs
 x = x.groupby(level=0).first()
@@ -49,75 +54,74 @@ p = ProgressBar(x.shape[0])
 for i, CID in enumerate(x.index):
     p.animate(i)
     odor_info = o.get_compound_odor(CID)
-    x.loc[CID, 'n_odor_mentions'] = int(len(odor_info))
-    x.loc[CID, 'odor'] = ';'.join(odor_info)
+    x.loc[CID, "n_odor_mentions"] = int(len(odor_info))
+    x.loc[CID, "odor"] = ";".join(odor_info)
 
 # +
 kinds = {}
 
 # Which CIDs contain no odor info
-kinds['nothing'] = x[x['odor']==''].index
+kinds["nothing"] = x[x["odor"] == ""].index
 
 # Which CIDs are claimed to be odorless
-kinds['odorless'] = x[x['odor'].str.lower().str.contains('odorless')].index
+kinds["odorless"] = x[x["odor"].str.lower().str.contains("odorless")].index
 
 # Which CIDs have some other kind of odor information
-kinds['odorous'] = x[~x.index.isin(kinds['nothing']) &
-                     ~x.index.isin(kinds['odorless'])].index
+kinds["odorous"] = x[~x.index.isin(kinds["nothing"]) & ~x.index.isin(kinds["odorless"])].index
 
 for kind in kinds:
     print("There are %d compounds in '%s'" % (len(kinds[kind]), kind))
 # -
 
 # Get basic molecular properties (MW and octanol/water partition coefficient)
-records = o.from_cids(x.index, property_list=['MolecularWeight', 'XlogP'])
+records = o.from_cids(x.index, property_list=["MolecularWeight", "XlogP"])
 
 # Add these records to the dataframe
 # Skip XLogP when it isn't found
 for record in records:
-    x.loc[record['CID'], 'MW'] = record['MolecularWeight']
+    x.loc[record["CID"], "MW"] = record["MolecularWeight"]
     try:
-        x.loc[record['CID'], 'XLogP'] = record['XLogP']
+        x.loc[record["CID"], "XLogP"] = record["XLogP"]
     except KeyError:
-        print(record['name'])
+        print(record["name"])
 
 plt.figure()
 ax = plt.gca()
-for color, kind in {'r':'nothing', 'g':'odorless', 'b':'odorous'}.items():
-    x.loc[kinds[kind]].plot.scatter(x='MW', y='XLogP', alpha=0.5, c=color, ax=ax, label=kind)
-plt.xscale('log')
-plt.xlim(10,1000)
-plt.ylim(-10,10)
+for color, kind in {"r": "nothing", "g": "odorless", "b": "odorous"}.items():
+    x.loc[kinds[kind]].plot.scatter(x="MW", y="XLogP", alpha=0.5, c=color, ax=ax, label=kind)
+plt.xscale("log")
+plt.xlim(10, 1000)
+plt.ylim(-10, 10)
 
 # Add odorant boiling point data from PubChem
 p = ProgressBar(x.shape[0])
 for i, cid in enumerate(x.index):
     p.animate(i)
-    z = o.get_compound_summary(cid, 'Boiling Point')
+    z = o.get_compound_summary(cid, "Boiling Point")
     if z and len(z):
-        x.loc[cid, 'BP'] = str(o._parse_other_info(z)[0])
+        x.loc[cid, "BP"] = str(o._parse_other_info(z)[0])
 
 # Parse this into boiling points in Celsius
-for cid, bp_raw in x['BP'].iteritems():
-    if isinstance(bp_raw,str):#math.isnan(bp_raw):
+for cid, bp_raw in x["BP"].iteritems():
+    if isinstance(bp_raw, str):  # math.isnan(bp_raw):
         num = re.findall("[-+]?[0-9]*\.?[0-9]+", bp_raw)[0]
         units = None
-        if any([s in bp_raw for s in ['° F','°F','deg F','DEG F']]):
-            units = 'F' 
-        if any([s in bp_raw for s in ['° C','°C','deg C','DEG C']]):
-            units = 'C'
-        #print(cid, num, units)
-        if units == 'C':
+        if any([s in bp_raw for s in ["° F", "°F", "deg F", "DEG F"]]):
+            units = "F"
+        if any([s in bp_raw for s in ["° C", "°C", "deg C", "DEG C"]]):
+            units = "C"
+        # print(cid, num, units)
+        if units == "C":
             bp_C = float(num)
-        elif units == 'F':
-            bp_C = (5.0/9) * (float(num) - 40)
+        elif units == "F":
+            bp_C = (5.0 / 9) * (float(num) - 40)
         if units:
-            x.loc[cid, 'BP_C'] = bp_C
+            x.loc[cid, "BP_C"] = bp_C
 
 plt.figure()
 ax = plt.gca()
-for color, kind in {'r':'nothing', 'g':'odorless', 'b':'odorous'}.items():
-    x.loc[kinds[kind]].plot.scatter(x='BP_C', y='XLogP', alpha=0.5, c=color, ax=ax, label=kind)
-plt.xscale('log')
-plt.xlim(10,1000)
-plt.ylim(-10,10)
+for color, kind in {"r": "nothing", "g": "odorless", "b": "odorous"}.items():
+    x.loc[kinds[kind]].plot.scatter(x="BP_C", y="XLogP", alpha=0.5, c=color, ax=ax, label=kind)
+plt.xscale("log")
+plt.xlim(10, 1000)
+plt.ylim(-10, 10)

--- a/notebooks/pubchem-scrape-odorless.py
+++ b/notebooks/pubchem-scrape-odorless.py
@@ -28,11 +28,9 @@ import numpy as np
 import pandas as pd
 import requests
 # %matplotlib inline
-from IPython.display import HTML, display
 from tqdm.auto import tqdm
 
 import pyrfume
-from pyrfume import pubchem
 
 
 def update_results(records, results):
@@ -41,7 +39,7 @@ def update_results(records, results):
     for annotation in records["Annotations"]["Annotation"]:
         try:
             cids = annotation["LinkedRecords"]["CID"]
-        except:
+        except Exception:
             pass
         else:
             strings = []
@@ -134,7 +132,7 @@ ambiguous_phrases = ["odoratus"]
 
 
 def make_html(all_statements):
-    ### Make an HTML file with the statements and their encoding.
+    """Make an HTML file with the statements and their encoding."""
     html = ""
     for cid, statements in all_statements.items():
         for statement in statements:
@@ -169,7 +167,7 @@ df.index.name = "CID"
 
 # Fill this dataframe with the assignment (odor, odorless, or (!!) both),
 # and the corresponding statements supporting that assignment
-for cid in sorted(all_statements):
+for cid in sorted(all_statements):  # noqa: C901 (too complex -- TODO)
     statements = all_statements[cid]
     odor = False
     odorless = False

--- a/notebooks/pubchem-scrape-odorless.py
+++ b/notebooks/pubchem-scrape-odorless.py
@@ -19,7 +19,7 @@
 # - For the slights/blands, it's not that I think the label inherently means odorless.
 # - I would also add "mild" to that list - found that one a few times since I sent the first e-mail.
 # - Maybe we could pull the slight/bland/mild odors and do some more visual inspection.-
-# - If the majority are improbable odors we can drop the set. 
+# - If the majority are improbable odors we can drop the set.
 
 # %matplotlib inline
 from IPython.display import HTML, display
@@ -35,18 +35,18 @@ from tqdm.auto import tqdm
 
 def update_results(records, results):
     """For a given set of PubChem records, add any strings with the matching keywords to the list of results"""
-    keywords = ('odor', 'odour', 'smell', 'aroma ', 'aroma,', 'aroma.', 'fragrance')
-    for annotation in records['Annotations']['Annotation']:
+    keywords = ("odor", "odour", "smell", "aroma ", "aroma,", "aroma.", "fragrance")
+    for annotation in records["Annotations"]["Annotation"]:
         try:
-            cids = annotation['LinkedRecords']['CID']
+            cids = annotation["LinkedRecords"]["CID"]
         except:
             pass
         else:
-            strings = [] 
-            for x in annotation['Data']:
-                for y in x['Value']['StringWithMarkup']:
-                    if any([z in y['String'].lower() for z in keywords]):
-                        strings.append(y['String'])
+            strings = []
+            for x in annotation["Data"]:
+                for y in x["Value"]["StringWithMarkup"]:
+                    if any([z in y["String"].lower() for z in keywords]):
+                        strings.append(y["String"])
             for cid in cids:
                 if cid in results:
                     results[cid] += strings
@@ -61,13 +61,15 @@ def get_results(heading):
     results = {}
     with tqdm(total=100) as pbar:
         while True:
-            url = (f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
-                   f"JSON?heading_type=Compound&heading={heading}&page={page}")
+            url = (
+                f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
+                f"JSON?heading_type=Compound&heading={heading}&page={page}"
+            )
             response = requests.get(url)
             records = response.json()
             update_results(records, results)
-            totalPages = records['Annotations']['TotalPages']
-            if page==1:
+            totalPages = records["Annotations"]["TotalPages"]
+            if page == 1:
                 pbar.reset(total=totalPages)
             pbar.set_description("%d CIDs described" % len(results))
             pbar.update()
@@ -80,11 +82,11 @@ def get_results(heading):
 def make_hist(results):
     """Show a histogram of results by PubChem ID number
     This is useful for showing the density of information as you get to more and more obscure molecules"""
-    plt.hist(np.log10(list(results.keys())), bins=np.arange(10));
+    plt.hist(np.log10(list(results.keys())), bins=np.arange(10))
     xticks = np.arange(10)
-    plt.xticks(xticks, ['$10^%d$' % x for x in xticks]);
-    plt.xlabel('PubChem ID')
-    plt.ylabel('Entry Count')
+    plt.xticks(xticks, ["$10^%d$" % x for x in xticks])
+    plt.xlabel("PubChem ID")
+    plt.ylabel("Entry Count")
 
 
 # Get all results from PubChem under the "Physical Description" heading
@@ -120,12 +122,14 @@ def color(cid, s, code):
     """A function for color styling in the HTML output"""
     return "<p style='color: %s'>%d: %s</p>" % (code, cid, s)
 
+
 # Assignment of particular phrases, matched via regular expressions, to the odorous, odorless, and ambiguous categories.
 # Refine as needed.
 # 'aroma' needs the trailing space to avoid matching 'aromatic' which has chemical but not necessarily olfactory implications
-odorous_phrases = ['odor', 'odour', 'smell', 'fragrance', 'aroma ', 'sense of smell']
-odorless_phrases = ['no odor', 'no odour', 'no smell', 'no fragrance', 'odorless', 'odourless']
-ambiguous_phrases = ['odoratus']
+odorous_phrases = ["odor", "odour", "smell", "fragrance", "aroma ", "sense of smell"]
+odorless_phrases = ["no odor", "no odour", "no smell", "no fragrance", "odorless", "odourless"]
+ambiguous_phrases = ["odoratus"]
+
 
 def make_html(all_statements):
     ### Make an HTML file with the statements and their encoding.
@@ -134,32 +138,32 @@ def make_html(all_statements):
         for statement in statements:
             statement = statement.lower()
             if any([re.findall(phrase, statement) for phrase in odorless_phrases]):
-                html += color(cid, statement, '#DD0000')
+                html += color(cid, statement, "#DD0000")
             elif any([re.findall(phrase, statement) for phrase in ambiguous_phrases]):
-                html += color(cid, statement, '#000000')
+                html += color(cid, statement, "#000000")
             elif any([re.findall(phrase, statement) for phrase in odorous_phrases]):
-                html += color(cid, statement, '#009900')
+                html += color(cid, statement, "#009900")
             else:
-                html += color(cid, statement, '#000000')
+                html += color(cid, statement, "#000000")
     return html
+
 
 # Create the HTML file
 html = make_html(all_statements)
 
 # Save the HTML file
-with open('../../pyrfume-data/pubchem/pubchem_scrape.html', 'w') as f:
+with open("../../pyrfume-data/pubchem/pubchem_scrape.html", "w") as f:
     f.write(html)
 # -
 
 # Save a Python pickle file of all the statements in the Pyrfume data repository
-path = 'pubchem/pubchem_scrape.pkl'
+path = "pubchem/pubchem_scrape.pkl"
 pyrfume.save_data(all_statements, path)
 
 # +
 # Create a dataframe to store the statements
-df = pd.DataFrame(index=sorted(all_statements),
-                  columns=['Odor', 'Odorless', 'Statements'])
-df.index.name = 'CID'
+df = pd.DataFrame(index=sorted(all_statements), columns=["Odor", "Odorless", "Statements"])
+df.index.name = "CID"
 
 # Fill this dataframe with the assignment (odor, odorless, or (!!) both),
 # and the corresponding statements supporting that assignment
@@ -169,36 +173,36 @@ for cid in sorted(all_statements):
     odorless = False
     for statement in statements:
         statement = statement.lower()
-        if re.findall('no odor', statement):
+        if re.findall("no odor", statement):
             odorless = True
-        elif re.findall('no odour', statement):
+        elif re.findall("no odour", statement):
             odorless = True
-        elif re.findall('no smell', statement):
+        elif re.findall("no smell", statement):
             odorless = True
-        elif re.findall('no fragrance', statement):
+        elif re.findall("no fragrance", statement):
             odorless = True
-        elif re.findall('odorless', statement):
+        elif re.findall("odorless", statement):
             odorless = True
-        elif re.findall('odourless', statement):
+        elif re.findall("odourless", statement):
             odorless = True
-        elif re.findall('odoratus', statement):
+        elif re.findall("odoratus", statement):
             pass
-        elif re.findall('sense of smell', statement):
+        elif re.findall("sense of smell", statement):
             odor = True
-        elif re.findall('odor', statement):
+        elif re.findall("odor", statement):
             odor = True
-        elif re.findall('odour', statement):
+        elif re.findall("odour", statement):
             odor = True
-        elif re.findall('smell', statement):
+        elif re.findall("smell", statement):
             odor = True
-        elif re.findall('fragrance', statement):
+        elif re.findall("fragrance", statement):
             odor = True
-        elif re.findall('aroma ', statement):
+        elif re.findall("aroma ", statement):
             odor = True
         else:
             pass
     # Uncomment the two lines below to see cases where this happens.
-    #if odor and odorless:
+    # if odor and odorless:
     #    print("\nOdorous and odorless! Statements were: " + str(statements))
     df.loc[cid, :] = [odor, odorless, statements]
 # -

--- a/notebooks/pubchem-scrape-odorless.py
+++ b/notebooks/pubchem-scrape-odorless.py
@@ -27,7 +27,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import requests
-# %matplotlib inline
 from tqdm.auto import tqdm
 
 import pyrfume

--- a/notebooks/pubchem-scrape-odorless.py
+++ b/notebooks/pubchem-scrape-odorless.py
@@ -21,16 +21,18 @@
 # - Maybe we could pull the slight/bland/mild odors and do some more visual inspection.-
 # - If the majority are improbable odors we can drop the set.
 
-# %matplotlib inline
-from IPython.display import HTML, display
+import re
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import requests
+# %matplotlib inline
+from IPython.display import HTML, display
+from tqdm.auto import tqdm
+
 import pyrfume
 from pyrfume import pubchem
-import re
-import requests
-from tqdm.auto import tqdm
 
 
 def update_results(records, results):

--- a/notebooks/pubchem-scrape-optical-rotation.py
+++ b/notebooks/pubchem-scrape-optical-rotation.py
@@ -18,5 +18,5 @@ from pyrfume import pubchem
 
 results = pubchem.get_results("Optical+Rotation")
 
-path = 'pubchem_optical_rotation/physics.pkl'
+path = "pubchem_optical_rotation/physics.pkl"
 pyrfume.save_data(results, path)

--- a/notebooks/pubchem-scrape-vapor-pressure.py
+++ b/notebooks/pubchem-scrape-vapor-pressure.py
@@ -18,7 +18,6 @@ import json
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
-# %matplotlib inline
 from tqdm.auto import tqdm
 
 

--- a/notebooks/pubchem-scrape-vapor-pressure.py
+++ b/notebooks/pubchem-scrape-vapor-pressure.py
@@ -14,11 +14,13 @@
 # ---
 
 import json
+
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
 # %matplotlib inline
 from tqdm.auto import tqdm
+
 
 def update_results(records, results):
     for annotation in records["Annotations"]["Annotation"]:

--- a/notebooks/pubchem-scrape-vapor-pressure.py
+++ b/notebooks/pubchem-scrape-vapor-pressure.py
@@ -13,15 +13,17 @@
 #     name: python3
 # ---
 
-# %matplotlib inline
-from IPython.display import HTML, display
+import re
+
 import matplotlib.pyplot as plt
 import numpy as np
+import requests
+# %matplotlib inline
+from IPython.display import HTML, display
+from tqdm.auto import tqdm
+
 import pyrfume
 from pyrfume import pubchem
-import re
-import requests
-from tqdm.auto import tqdm
 
 
 def update_results(records, results):

--- a/notebooks/pubchem-scrape-vapor-pressure.py
+++ b/notebooks/pubchem-scrape-vapor-pressure.py
@@ -13,25 +13,18 @@
 #     name: python3
 # ---
 
-import re
-
+import json
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
 # %matplotlib inline
-from IPython.display import HTML, display
 from tqdm.auto import tqdm
 
-import pyrfume
-from pyrfume import pubchem
-
-
 def update_results(records, results):
-    keywords = ("odor", "odour", "smell", "aroma ", "aroma,", "aroma.", "fragrance")
     for annotation in records["Annotations"]["Annotation"]:
         try:
             cids = annotation["LinkedRecords"]["CID"]
-        except:
+        except Exception:
             pass
         else:
             strings = []
@@ -93,7 +86,6 @@ for cid in cids:
     all_statements[cid] = ps
 len(all_statements)
 
-import json
 
 with open("pubchem-vapor-pressure.json", "w") as f:
     json.dump(all_statements, f)

--- a/notebooks/pubchem-scrape-vapor-pressure.py
+++ b/notebooks/pubchem-scrape-vapor-pressure.py
@@ -25,17 +25,17 @@ from tqdm.auto import tqdm
 
 
 def update_results(records, results):
-    keywords = ('odor', 'odour', 'smell', 'aroma ', 'aroma,', 'aroma.', 'fragrance')
-    for annotation in records['Annotations']['Annotation']:
+    keywords = ("odor", "odour", "smell", "aroma ", "aroma,", "aroma.", "fragrance")
+    for annotation in records["Annotations"]["Annotation"]:
         try:
-            cids = annotation['LinkedRecords']['CID']
+            cids = annotation["LinkedRecords"]["CID"]
         except:
             pass
         else:
-            strings = [] 
-            for x in annotation['Data']:
-                for y in x['Value']['StringWithMarkup']:
-                    strings.append(y['String'])
+            strings = []
+            for x in annotation["Data"]:
+                for y in x["Value"]["StringWithMarkup"]:
+                    strings.append(y["String"])
             for cid in cids:
                 if cid in results:
                     results[cid] += strings
@@ -48,13 +48,15 @@ def get_results(heading):
     results = {}
     with tqdm(total=100) as pbar:
         while True:
-            url = (f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
-                   f"JSON?heading_type=Compound&heading={heading}&page={page}")
+            url = (
+                f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
+                f"JSON?heading_type=Compound&heading={heading}&page={page}"
+            )
             response = requests.get(url)
             records = response.json()
             update_results(records, results)
-            totalPages = records['Annotations']['TotalPages']
-            if page==1:
+            totalPages = records["Annotations"]["TotalPages"]
+            if page == 1:
                 pbar.reset(total=totalPages)
             pbar.set_description("%d CIDs described" % len(results))
             pbar.update()
@@ -69,12 +71,13 @@ pd_results = get_results("Vapor+Pressure")
 
 # +
 def make_hist(results):
-    plt.hist(np.log10(list(results.keys())), bins=np.arange(10));
+    plt.hist(np.log10(list(results.keys())), bins=np.arange(10))
     xticks = np.arange(10)
-    plt.xticks(xticks, ['$10^%d$' % x for x in xticks]);
-    plt.xlabel('PubChem ID')
-    plt.ylabel('Entry Count')
-    
+    plt.xticks(xticks, ["$10^%d$" % x for x in xticks])
+    plt.xlabel("PubChem ID")
+    plt.ylabel("Entry Count")
+
+
 make_hist(pd_results)
 # -
 
@@ -89,5 +92,6 @@ for cid in cids:
 len(all_statements)
 
 import json
-with open('pubchem-vapor-pressure.json', 'w') as f:
+
+with open("pubchem-vapor-pressure.json", "w") as f:
     json.dump(all_statements, f)

--- a/notebooks/pubchem-smiles.py
+++ b/notebooks/pubchem-smiles.py
@@ -23,11 +23,11 @@ import pandas as pd
 import pyrfume
 from pyrfume.odorants import from_cids
 
-if 'results' not in locals():
+if "results" not in locals():
     results = {}
 n = int(1e5)
-by = int(1e4) # In case there are errors, we will only have to go back this far
-for first in range(1, n+1, by):
+by = int(1e4)  # In case there are errors, we will only have to go back this far
+for first in range(1, n + 1, by):
     if first not in results:
         last = first + by
         x = from_cids(range(first, last))
@@ -35,8 +35,6 @@ for first in range(1, n+1, by):
 
 results.keys()
 
-df = pd.concat([pd.DataFrame(results[x]).set_index('CID') for x in results])
+df = pd.concat([pd.DataFrame(results[x]).set_index("CID") for x in results])
 
-pyrfume.save_data(df, 'odorants/cids-smiles-pubchem-100000.csv')
-
-
+pyrfume.save_data(df, "odorants/cids-smiles-pubchem-100000.csv")

--- a/notebooks/pubchem-smiles.py
+++ b/notebooks/pubchem-smiles.py
@@ -20,6 +20,7 @@
 # %autoreload 2
 
 import pandas as pd
+
 import pyrfume
 from pyrfume.odorants import from_cids
 

--- a/notebooks/sdf_to_cids_smiles_mol.py
+++ b/notebooks/sdf_to_cids_smiles_mol.py
@@ -22,18 +22,17 @@ from rdkit import Chem
 import pyrfume
 from pyrfume import odorants
 from rickpy import ProgressBar
+
 # -
 
 # ## Create a dictionary of mol files
 
-file_path = os.path.join(pyrfume.DATA, 'all_cids.sdf')
+file_path = os.path.join(pyrfume.DATA, "all_cids.sdf")
 f = Chem.SDMolSupplier(file_path)
 result = {}
 for mol in f:
-    x = mol.GetProp('_Name')
-    cid, smiles = x.split(':')
+    x = mol.GetProp("_Name")
+    cid, smiles = x.split(":")
     cid = int(cid)
     smiles = smiles.strip()
-    result[cid] = {'smiles': smiles, 'mol': mol}
-
-
+    result[cid] = {"smiles": smiles, "mol": mol}

--- a/notebooks/sdf_to_cids_smiles_mol.py
+++ b/notebooks/sdf_to_cids_smiles_mol.py
@@ -18,10 +18,10 @@ import os
 
 import pandas as pd
 from rdkit import Chem
+from rickpy import ProgressBar
 
 import pyrfume
 from pyrfume import odorants
-from rickpy import ProgressBar
 
 # -
 

--- a/notebooks/sdf_to_cids_smiles_mol.py
+++ b/notebooks/sdf_to_cids_smiles_mol.py
@@ -16,12 +16,9 @@
 # +
 import os
 
-import pandas as pd
 from rdkit import Chem
-from rickpy import ProgressBar
 
 import pyrfume
-from pyrfume import odorants
 
 # -
 

--- a/notebooks/senselab.py
+++ b/notebooks/senselab.py
@@ -13,11 +13,12 @@
 #     name: python3
 # ---
 
+import os
+from urllib.request import urlopen
+
 # +
 import bs4
-import os
 import pandas as pd
-from urllib.request import urlopen
 
 import pyrfume
 from pyrfume import odorants

--- a/notebooks/senselab.py
+++ b/notebooks/senselab.py
@@ -21,61 +21,62 @@ from urllib.request import urlopen
 
 import pyrfume
 from pyrfume import odorants
+
 # -
 
 # Scrape compounds names and links from SenseLab
 info = []
-for page in range(1,8):
-    url = 'https://senselab.med.yale.edu/OdorDB/Browse?db=5&cl=1&page=%d' % page
+for page in range(1, 8):
+    url = "https://senselab.med.yale.edu/OdorDB/Browse?db=5&cl=1&page=%d" % page
     f = urlopen(url)
     html = f.read()
     soup = bs4.BeautifulSoup(html)
-    table = soup.find('table')
-    for span in table.find_all('span'):
+    table = soup.find("table")
+    for span in table.find_all("span"):
         name = span.text.strip()
-        link = span.find('a').get('href')
+        link = span.find("a").get("href")
         info.append((name, link))
 
 # Make into a dataframe
-df = pd.DataFrame.from_records(info, columns=['name', 'url'])
+df = pd.DataFrame.from_records(info, columns=["name", "url"])
 df.head()
 
 # Get CIDS by searching the names
-cids = odorants.get_cids(df['name'], kind='name')
+cids = odorants.get_cids(df["name"], kind="name")
 
 # Add these CIDs to the dataframe
-df = df.set_index('name').join(pd.Series(cids, name='CID'))
+df = df.set_index("name").join(pd.Series(cids, name="CID"))
 
 # Get CAS strings for compounds with no CID was found based on the name
-for name, url_suffix in df[df['CID']==0]['url'].items():
-    url = 'https://senselab.med.yale.edu/OdorDB/%s' % url_suffix
+for name, url_suffix in df[df["CID"] == 0]["url"].items():
+    url = "https://senselab.med.yale.edu/OdorDB/%s" % url_suffix
     f = urlopen(url)
     html = f.read()
     soup = bs4.BeautifulSoup(html)
-    table = soup.find('table')
-    cas_row = table.find_all('tr')[5]
-    cas_text = cas_row.find_all('span')[-1].text
-    cas = cas_text.replace('\r\n','').strip()
-    df.loc[name, 'CAS'] = cas
+    table = soup.find("table")
+    cas_row = table.find_all("tr")[5]
+    cas_text = cas_row.find_all("span")[-1].text
+    cas = cas_text.replace("\r\n", "").strip()
+    df.loc[name, "CAS"] = cas
 
 # +
 # Add CIDs obtained from searching the CAS string
-for name, cas in df[df['CAS'].notnull()]['CAS'].items():
+for name, cas in df[df["CAS"].notnull()]["CAS"].items():
     if cas:
-        cid = odorants.get_cid(cas, kind='name')
-        df.loc[name, 'CID'] = cid
-        
+        cid = odorants.get_cid(cas, kind="name")
+        df.loc[name, "CID"] = cid
+
 # Fill remaining missing CIDs with 0
-df.loc[:, 'CID'] = df['CID'].fillna(0)
+df.loc[:, "CID"] = df["CID"].fillna(0)
 # -
 
 # Manual fills
-df.loc['2,4,5-TRIMETHYLTHIAZOLINE', 'CID'] = 263626
-df.loc['METHYLSALICYLATE', 'CID'] = 4133
-df.loc['PHENYLETHYL ALCOHOL (PEA)', 'CID'] = 6054
-df.loc['Perillaalcohol', 'CID'] = 10819
-df.loc['Perillaaldehyde', 'CID'] = 16441
-#df[df['CID']==0]
+df.loc["2,4,5-TRIMETHYLTHIAZOLINE", "CID"] = 263626
+df.loc["METHYLSALICYLATE", "CID"] = 4133
+df.loc["PHENYLETHYL ALCOHOL (PEA)", "CID"] = 6054
+df.loc["Perillaalcohol", "CID"] = 10819
+df.loc["Perillaaldehyde", "CID"] = 16441
+# df[df['CID']==0]
 
-file_path = os.path.join(pyrfume.DATA, 'senselab.csv')
+file_path = os.path.join(pyrfume.DATA, "senselab.csv")
 df.to_csv(file_path)

--- a/notebooks/sigma_ff.py
+++ b/notebooks/sigma_ff.py
@@ -23,17 +23,17 @@ descriptors, data = sigma_ff.get_data()
 
 # Turn CAS into CIDs
 cas_list = list(data.keys())
-results = odorants.get_cids(cas_list, kind='name', verbose=False)
+results = odorants.get_cids(cas_list, kind="name", verbose=False)
 
 # Format Sigma FF data into Dataframe with CIDs
 # Odorants without CIDs will have a CID of 0
-sigma = pd.DataFrame(index=cas_list, columns=['CID']+descriptors, data=0)
-sigma.index.name = 'CAS'
+sigma = pd.DataFrame(index=cas_list, columns=["CID"] + descriptors, data=0)
+sigma.index.name = "CAS"
 for cas, desc in data.items():
-    sigma.loc[cas, 'CID'] = results[cas]
-    sigma.loc[cas, desc] = 1    
+    sigma.loc[cas, "CID"] = results[cas]
+    sigma.loc[cas, desc] = 1
 sigma.head()
 
 # Create a new file with CIDs and store here in `cids` dictionary
-file_path = os.path.join(pyrfume.DATA, 'sigma', 'sigma.csv')
+file_path = os.path.join(pyrfume.DATA, "sigma", "sigma.csv")
 sigma.to_csv(file_path)

--- a/notebooks/sigma_ff.py
+++ b/notebooks/sigma_ff.py
@@ -14,9 +14,11 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
-from pyrfume import sigma_ff, odorants
+from pyrfume import odorants, sigma_ff
 
 # Load raw Sigma FF data
 descriptors, data = sigma_ff.get_data()

--- a/notebooks/snitz-dragon-selection.py
+++ b/notebooks/snitz-dragon-selection.py
@@ -13,15 +13,16 @@
 #     name: python3
 # ---
 
+import pickle
+
+import matplotlib.pyplot as plt
 # %matplotlib inline
 import numpy as np
 import pandas as pd
 from fancyimpute import KNN
-from sklearn.preprocessing import MinMaxScaler, Normalizer
-import pickle
 from sklearn.linear_model import Lasso
-import matplotlib.pyplot as plt
 from sklearn.model_selection import ShuffleSplit, cross_validate
+from sklearn.preprocessing import MinMaxScaler, Normalizer
 
 # ### Load Snitz Dataset #1
 

--- a/notebooks/snitz-dragon-selection.py
+++ b/notebooks/snitz-dragon-selection.py
@@ -16,7 +16,6 @@
 import pickle
 
 import matplotlib.pyplot as plt
-# %matplotlib inline
 import numpy as np
 import pandas as pd
 from fancyimpute import KNN
@@ -24,7 +23,7 @@ from sklearn.linear_model import Lasso
 from sklearn.model_selection import ShuffleSplit, cross_validate
 from sklearn.preprocessing import MinMaxScaler, Normalizer
 
-# ### Load Snitz Dataset #1
+# Load Snitz Dataset #1
 
 df1 = pd.read_csv(
     "data/snitz/experiment1_comparisons.csv", header=0, index_col=0, names=["A", "B", "Similarity"]
@@ -41,7 +40,7 @@ df1.shape[0], len(set(df1[["A", "B"]].values.ravel()))
 
 df1.hist("Similarity")
 
-# ### Load Snitz Dataset #2
+# Load Snitz Dataset #2
 
 df2 = pd.read_csv(
     "data/snitz/experiment2_comparisons.csv", header=0, index_col=0, names=["A", "B", "Similarity"]

--- a/notebooks/snitz-dragon-selection.py
+++ b/notebooks/snitz-dragon-selection.py
@@ -170,7 +170,7 @@ plt.plot(1 + np.arange(len(model.coef_)), sorted(np.abs(model.coef_))[::-1])
 plt.xscale("log")
 
 # +
-from sklearn.model_selection import cross_validate, ShuffleSplit
+from sklearn.model_selection import ShuffleSplit, cross_validate
 
 
 def r_score(model, X, y_true):

--- a/notebooks/snitz-dragon-selection.py
+++ b/notebooks/snitz-dragon-selection.py
@@ -21,50 +21,57 @@ from sklearn.preprocessing import MinMaxScaler, Normalizer
 
 # ### Load Snitz Dataset #1
 
-df1 = pd.read_csv('data/snitz/experiment1_comparisons.csv',
-            header=0,index_col=0,names=['A','B','Similarity'])
-df1_cids = pd.read_csv('data/snitz/experiment1_cids.csv', index_col=0)
-df1_cids = df1_cids.applymap(lambda x:x.replace('[','').replace(']','').strip().replace(' ',','))
+df1 = pd.read_csv(
+    "data/snitz/experiment1_comparisons.csv", header=0, index_col=0, names=["A", "B", "Similarity"]
+)
+df1_cids = pd.read_csv("data/snitz/experiment1_cids.csv", index_col=0)
+df1_cids = df1_cids.applymap(
+    lambda x: x.replace("[", "").replace("]", "").strip().replace(" ", ",")
+)
 df1_cids
-df1.loc[:, ['A','B']] = df1.loc[:, ['A','B']].applymap(lambda x:df1_cids.loc[x]['Mixture Cids'])
+df1.loc[:, ["A", "B"]] = df1.loc[:, ["A", "B"]].applymap(lambda x: df1_cids.loc[x]["Mixture Cids"])
 df1.head()
 
-df1.shape[0],len(set(df1[['A','B']].values.ravel()))
+df1.shape[0], len(set(df1[["A", "B"]].values.ravel()))
 
-df1.hist('Similarity');
+df1.hist("Similarity")
 
 # ### Load Snitz Dataset #2
 
-df2 = pd.read_csv('data/snitz/experiment2_comparisons.csv',
-            header=0,index_col=0,names=['A','B','Similarity'])
-df2_cids = pd.read_csv('data/snitz/experiment2_cids.csv', index_col=0)
-df2_cids = df2_cids.applymap(lambda x:x.replace('[','').replace(']','').strip().replace(' ',','))
+df2 = pd.read_csv(
+    "data/snitz/experiment2_comparisons.csv", header=0, index_col=0, names=["A", "B", "Similarity"]
+)
+df2_cids = pd.read_csv("data/snitz/experiment2_cids.csv", index_col=0)
+df2_cids = df2_cids.applymap(
+    lambda x: x.replace("[", "").replace("]", "").strip().replace(" ", ",")
+)
 df2_cids
-df2.loc[:, ['A','B']] = df2.loc[:, ['A','B']].applymap(lambda x:df2_cids.loc[x]['Mixture Cids'])
+df2.loc[:, ["A", "B"]] = df2.loc[:, ["A", "B"]].applymap(lambda x: df2_cids.loc[x]["Mixture Cids"])
 df2.head()
 
-df2.shape[0],len(set(df2[['A','B']].values.ravel()))
+df2.shape[0], len(set(df2[["A", "B"]].values.ravel()))
 
-df2.hist('Similarity');
+df2.hist("Similarity")
 
 # ### Load Snitz Dataset #3
 
-df3 = pd.read_csv('data/snitz/experiment3_comparisons.csv',
-            header=0,index_col=0,names=['A','B','Similarity'])
+df3 = pd.read_csv(
+    "data/snitz/experiment3_comparisons.csv", header=0, index_col=0, names=["A", "B", "Similarity"]
+)
 df3.head()
 
-df3.shape[0],len(set(df3[['A','B']].values.ravel()))
+df3.shape[0], len(set(df3[["A", "B"]].values.ravel()))
 
-df3.hist('Similarity');
+df3.hist("Similarity")
 
 # ### Get all Snitz CIDs
 
 snitz_cids = []
-for x in df1_cids['Mixture Cids']:
-    snitz_cids += x.split(',')
-for x in df2_cids['Mixture Cids']:
-    snitz_cids += x.split(',')
-for x in df3[['A','B']].values.ravel():
+for x in df1_cids["Mixture Cids"]:
+    snitz_cids += x.split(",")
+for x in df2_cids["Mixture Cids"]:
+    snitz_cids += x.split(",")
+for x in df3[["A", "B"]].values.ravel():
     snitz_cids += [x]
 snitz_cids = np.array(snitz_cids).astype(int)
 snitz_cids = set(snitz_cids)
@@ -73,14 +80,15 @@ print("There are %d distinct CIDs across all of the Snitz datasets" % len(snitz_
 # ### Load the Dragon data and scale each features to 0-1.
 
 # +
-df_dragon = pd.read_csv('data/cids-smiles-dragon.txt').set_index('CID')
-df_dragon = df_dragon.iloc[:, 1:] # Remove SMILES column
+df_dragon = pd.read_csv("data/cids-smiles-dragon.txt").set_index("CID")
+df_dragon = df_dragon.iloc[:, 1:]  # Remove SMILES column
 
 # Normalize every feature to [0, 1]
 mms = MinMaxScaler()
 df_dragon[:] = mms.fit_transform(df_dragon)
 import pickle
-with open('data/dragon-minmaxscaler.pickle', 'wb') as f:
+
+with open("data/dragon-minmaxscaler.pickle", "wb") as f:
     pickle.dump(mms, f)
 # -
 
@@ -100,21 +108,21 @@ for nd in no_dragon:
 # +
 # Remove bad features (too many NaNs) and impute remaining NaNs
 frac_bad = df_snitz_dragon.isnull().mean()
-good = frac_bad[frac_bad<0.3].index
+good = frac_bad[frac_bad < 0.3].index
 df_snitz_dragon = df_snitz_dragon.loc[:, good]
 
 knn = KNN(k=5)
 df_snitz_dragon[:] = knn.fit_transform(df_snitz_dragon.values)
 
 # +
-#from olfactometer.odorants import from_cids
-#pubchem_data = from_cids([int(x) for x in snitz_cids])
-#pd.DataFrame.from_dict(pubchem_data).set_index('CID').to_csv('data/snitz-odorant-info.csv')
+# from olfactometer.odorants import from_cids
+# pubchem_data = from_cids([int(x) for x in snitz_cids])
+# pd.DataFrame.from_dict(pubchem_data).set_index('CID').to_csv('data/snitz-odorant-info.csv')
 
 # +
-#df_snitz_mordred = pd.read_csv('data/snitz-mordred.csv').set_index('CID')
-#df_snitz_mordred[:] = mms.fit_transform(df_snitz_mordred.values)
-#df_snitz_mordred.head()
+# df_snitz_mordred = pd.read_csv('data/snitz-mordred.csv').set_index('CID')
+# df_snitz_mordred[:] = mms.fit_transform(df_snitz_mordred.values)
+# df_snitz_mordred.head()
 # -
 
 df_snitz_features = df_snitz_dragon
@@ -130,10 +138,10 @@ def get_unit_distance(row):
     of the angle between them"""
     a, b, similarity = row
     if isinstance(a, str):
-        a = [int(x) for x in a.split(',')]
-        b = [int(x) for x in b.split(',')]
-    A = df_snitz_features.loc[a,:].values
-    B = df_snitz_features.loc[b,:].values
+        a = [int(x) for x in a.split(",")]
+        b = [int(x) for x in b.split(",")]
+    A = df_snitz_features.loc[a, :].values
+    B = df_snitz_features.loc[b, :].values
     if A.ndim > 1:
         A = A.sum(axis=0)
         B = B.sum(axis=0)
@@ -146,26 +154,30 @@ df_distance = pd.concat([df1, df2, df3]).reset_index(drop=True)
 features = list(df_snitz_features.columns)
 unit_distances = df_distance.apply(get_unit_distance, axis=1)
 df_distance = df_distance.join(df_distance.apply(get_unit_distance, axis=1))
-df_distance.loc[:, 'Similarity'] /= 100
+df_distance.loc[:, "Similarity"] /= 100
 df_distance.head()
 
 # %matplotlib inline
 from sklearn.linear_model import Lasso
+
 model = Lasso(alpha=1e-4, max_iter=1e5)
 X = df_distance[features]
-y = df_distance['Similarity']
+y = df_distance["Similarity"]
 model.fit(X, y)
 import matplotlib.pyplot as plt
-plt.plot(1+np.arange(len(model.coef_)),sorted(np.abs(model.coef_))[::-1]);
-plt.xscale('log')
+
+plt.plot(1 + np.arange(len(model.coef_)), sorted(np.abs(model.coef_))[::-1])
+plt.xscale("log")
 
 # +
 from sklearn.model_selection import cross_validate, ShuffleSplit
 
+
 def r_score(model, X, y_true):
     y_pred = model.predict(X)
-    #print(y_true.shape, y_pred.shape)
-    return np.corrcoef(y_true, y_pred)[0,1]
+    # print(y_true.shape, y_pred.shape)
+    return np.corrcoef(y_true, y_pred)[0, 1]
+
 
 alphas = np.logspace(-5, -2, 9)
 n_splits = 25
@@ -177,22 +189,22 @@ for i, alpha in enumerate(alphas):
     print(alpha)
     model = Lasso(alpha=alpha, max_iter=1e5)
     fff = cross_validate(model, X, y, cv=cv, return_train_score=True, scoring=r_score)
-    training[i, :] = fff['train_score']
-    testing[i, :] = fff['test_score']
+    training[i, :] = fff["train_score"]
+    testing[i, :] = fff["test_score"]
 # -
 
-plt.errorbar(alphas, training.mean(axis=1), yerr=training.std(axis=1), label='Train')
-plt.errorbar(alphas, testing.mean(axis=1), yerr=testing.std(axis=1), label='Test')
-plt.xscale('log')
-plt.xlabel('Alpha')
-plt.ylabel('R')
+plt.errorbar(alphas, training.mean(axis=1), yerr=training.std(axis=1), label="Train")
+plt.errorbar(alphas, testing.mean(axis=1), yerr=testing.std(axis=1), label="Test")
+plt.xscale("log")
+plt.xlabel("Alpha")
+plt.ylabel("R")
 plt.legend()
 
 model = Lasso(alpha=1e-4, max_iter=1e5)
 model.fit(X, y)
 
-snitz_space_weights = pd.Series(model.coef_, index=features, name='Weight')
-snitz_space_weights = snitz_space_weights[np.abs(snitz_space_weights)>1e-5]
+snitz_space_weights = pd.Series(model.coef_, index=features, name="Weight")
+snitz_space_weights = snitz_space_weights[np.abs(snitz_space_weights) > 1e-5]
 snitz_space_weights
 
-snitz_space_weights.to_csv('data/snitz_dragon_weights.csv', header=True)
+snitz_space_weights.to_csv("data/snitz_dragon_weights.csv", header=True)

--- a/notebooks/snitz-dragon-selection.py
+++ b/notebooks/snitz-dragon-selection.py
@@ -18,6 +18,10 @@ import numpy as np
 import pandas as pd
 from fancyimpute import KNN
 from sklearn.preprocessing import MinMaxScaler, Normalizer
+import pickle
+from sklearn.linear_model import Lasso
+import matplotlib.pyplot as plt
+from sklearn.model_selection import ShuffleSplit, cross_validate
 
 # ### Load Snitz Dataset #1
 
@@ -86,7 +90,6 @@ df_dragon = df_dragon.iloc[:, 1:]  # Remove SMILES column
 # Normalize every feature to [0, 1]
 mms = MinMaxScaler()
 df_dragon[:] = mms.fit_transform(df_dragon)
-import pickle
 
 with open("data/dragon-minmaxscaler.pickle", "wb") as f:
     pickle.dump(mms, f)
@@ -158,19 +161,16 @@ df_distance.loc[:, "Similarity"] /= 100
 df_distance.head()
 
 # %matplotlib inline
-from sklearn.linear_model import Lasso
 
 model = Lasso(alpha=1e-4, max_iter=1e5)
 X = df_distance[features]
 y = df_distance["Similarity"]
 model.fit(X, y)
-import matplotlib.pyplot as plt
 
 plt.plot(1 + np.arange(len(model.coef_)), sorted(np.abs(model.coef_))[::-1])
 plt.xscale("log")
 
 # +
-from sklearn.model_selection import ShuffleSplit, cross_validate
 
 
 def r_score(model, X, y_true):

--- a/notebooks/sobel.py
+++ b/notebooks/sobel.py
@@ -14,9 +14,11 @@
 # ---
 
 import os
+
 import pandas as pd
+
 import pyrfume
-from pyrfume import snitz, odorants
+from pyrfume import odorants, snitz
 
 file_path = os.path.join(pyrfume.DATA, "snitz", "Snitz144.csv")
 snitz_data_raw = pd.read_csv(file_path)

--- a/notebooks/sobel.py
+++ b/notebooks/sobel.py
@@ -22,7 +22,7 @@ import pyrfume
 file_path = os.path.join(pyrfume.DATA, "snitz", "Snitz144.csv")
 snitz_data_raw = pd.read_csv(file_path)
 
-results = odorants.get_cids(snitz_data_raw["CAS"], kind="name", verbose=False)
+results = pyrfume.odorants.get_cids(snitz_data_raw["CAS"], kind="name", verbose=False)
 
 snitz_data = pd.Series(results, name="CID").to_frame().join(snitz_data_raw.set_index("CAS"))
 snitz_data.head()

--- a/notebooks/sobel.py
+++ b/notebooks/sobel.py
@@ -18,7 +18,6 @@ import os
 import pandas as pd
 
 import pyrfume
-from pyrfume import odorants, snitz
 
 file_path = os.path.join(pyrfume.DATA, "snitz", "Snitz144.csv")
 snitz_data_raw = pd.read_csv(file_path)

--- a/notebooks/sobel.py
+++ b/notebooks/sobel.py
@@ -18,13 +18,13 @@ import pandas as pd
 import pyrfume
 from pyrfume import snitz, odorants
 
-file_path = os.path.join(pyrfume.DATA, 'snitz', 'Snitz144.csv')
+file_path = os.path.join(pyrfume.DATA, "snitz", "Snitz144.csv")
 snitz_data_raw = pd.read_csv(file_path)
 
-results = odorants.get_cids(snitz_data_raw['CAS'], kind='name', verbose=False)
+results = odorants.get_cids(snitz_data_raw["CAS"], kind="name", verbose=False)
 
-snitz_data = pd.Series(results, name='CID').to_frame().join(snitz_data_raw.set_index('CAS'))
+snitz_data = pd.Series(results, name="CID").to_frame().join(snitz_data_raw.set_index("CAS"))
 snitz_data.head()
 
-file_path = os.path.join(pyrfume.DATA, 'snitz', 'snitz.csv')
+file_path = os.path.join(pyrfume.DATA, "snitz", "snitz.csv")
 snitz_data.to_csv(file_path)

--- a/notebooks/superscent.py
+++ b/notebooks/superscent.py
@@ -13,11 +13,12 @@
 #     name: python3
 # ---
 
+import os
+from urllib.request import urlopen
+
 # +
 import bs4
-import os
 import pandas as pd
-from urllib.request import urlopen
 
 import pyrfume
 

--- a/notebooks/superscent.py
+++ b/notebooks/superscent.py
@@ -20,34 +20,33 @@ import pandas as pd
 from urllib.request import urlopen
 
 import pyrfume
+
 # -
 
-url = 'http://bioinf-applied.charite.de/superscent/index.php?site=browse_scents'
+url = "http://bioinf-applied.charite.de/superscent/index.php?site=browse_scents"
 f = urlopen(url)
 html = f.read()
 soup = bs4.BeautifulSoup(html)
 
-groups = [x.text for x in soup.find_all('table')[1].find_all('td')]
+groups = [x.text for x in soup.find_all("table")[1].find_all("td")]
 groups
 
 cids = set()
 for group in groups:
     print(group)
-    url = 'http://bioinf-applied.charite.de/superscent/index.php?site=browse_scents&char=%s' % group
+    url = "http://bioinf-applied.charite.de/superscent/index.php?site=browse_scents&char=%s" % group
     f = urlopen(url)
     html = f.read()
     soup = bs4.BeautifulSoup(html)
-    results_table = soup.find_all('table')[2]
-    links = results_table.find_all('a')
-    print('%d links' % len(links))
+    results_table = soup.find_all("table")[2]
+    links = results_table.find_all("a")
+    print("%d links" % len(links))
     for link in links:
-        compound_url = link.get('href')
-        cid = int(compound_url.split('=')[-1])
+        compound_url = link.get("href")
+        cid = int(compound_url.split("=")[-1])
         cids.add(cid)
 
 len(cids)
 
-file_path = os.path.join(pyrfume.DATA, 'superscent_cids.txt')
-pd.Series(sorted(list(cids)), name='CID').to_csv(file_path, index=False, header=True)
-
-
+file_path = os.path.join(pyrfume.DATA, "superscent_cids.txt")
+pd.Series(sorted(list(cids)), name="CID").to_csv(file_path, index=False, header=True)

--- a/notebooks/thresholds-add-cids.py
+++ b/notebooks/thresholds-add-cids.py
@@ -20,6 +20,7 @@ from rickpy import ProgressBar
 
 import pyrfume
 from pyrfume.odorants import get_cid, get_cids
+from rdkit.Chem import MolFromSmiles, MolToSmiles
 
 df = pyrfume.load_data("thresholds/parsed_threshold_data_in_air.csv")
 df = df.set_index("canonical SMILES")
@@ -28,8 +29,6 @@ smiles_cids = get_cids(df.index, kind="SMILES")
 
 df = df.join(pd.Series(smiles_cids, name="CID"))
 df.head()
-
-from rdkit.Chem import MolFromSmiles, MolToSmiles
 
 df["SMILES"] = df.index
 p = ProgressBar(len(smiles_cids))

--- a/notebooks/thresholds-add-cids.py
+++ b/notebooks/thresholds-add-cids.py
@@ -19,39 +19,41 @@ import pandas as pd
 import pyrfume
 from pyrfume.odorants import get_cid, get_cids
 from rickpy import ProgressBar
-df = pyrfume.load_data('thresholds/parsed_threshold_data_in_air.csv')
-df = df.set_index('canonical SMILES')
 
-smiles_cids = get_cids(df.index, kind='SMILES')
+df = pyrfume.load_data("thresholds/parsed_threshold_data_in_air.csv")
+df = df.set_index("canonical SMILES")
 
-df = df.join(pd.Series(smiles_cids, name='CID'))
+smiles_cids = get_cids(df.index, kind="SMILES")
+
+df = df.join(pd.Series(smiles_cids, name="CID"))
 df.head()
 
 from rdkit.Chem import MolFromSmiles, MolToSmiles
-df['SMILES'] = df.index
+
+df["SMILES"] = df.index
 p = ProgressBar(len(smiles_cids))
 for i, (old, cid) in enumerate(smiles_cids.items()):
     p.animate(i, status=old)
     if cid == 0:
         mol = MolFromSmiles(old)
         if mol is None:
-            new = ''
+            new = ""
         else:
             new = MolToSmiles(mol, isomericSmiles=True)
             if old != new:
-                cid = get_cid(new, kind='SMILES')
-        df.loc[old, ['SMILES', 'CID']] = [new, cid]
-p.animate(i+1, status='Done')
+                cid = get_cid(new, kind="SMILES")
+        df.loc[old, ["SMILES", "CID"]] = [new, cid]
+p.animate(i + 1, status="Done")
 
-df[df['SMILES']=='']
+df[df["SMILES"] == ""]
 
-ozone_smiles = ozone_cid = get_cid('[O-][O+]=O', kind='SMILES')
-df.loc['O=[O]=O', ['SMILES', 'CID']] = [ozone_smiles, ozone_cid]
+ozone_smiles = ozone_cid = get_cid("[O-][O+]=O", kind="SMILES")
+df.loc["O=[O]=O", ["SMILES", "CID"]] = [ozone_smiles, ozone_cid]
 
-df = df.set_index('CID').drop(['ez_smiles'], axis=1)
+df = df.set_index("CID").drop(["ez_smiles"], axis=1)
 
-df = df.rename(columns={'author': 'year', 'year': 'author'})
+df = df.rename(columns={"author": "year", "year": "author"})
 
 df.head()
 
-pyrfume.save_data(df, 'thresholds/parsed_threshold_data_in_air_fixed.csv')
+pyrfume.save_data(df, "thresholds/parsed_threshold_data_in_air_fixed.csv")

--- a/notebooks/thresholds-add-cids.py
+++ b/notebooks/thresholds-add-cids.py
@@ -16,11 +16,11 @@
 # # Add CIDS to parsed_threshold_data_in_air.csv
 
 import pandas as pd
+from rdkit.Chem import MolFromSmiles, MolToSmiles
 from rickpy import ProgressBar
 
 import pyrfume
 from pyrfume.odorants import get_cid, get_cids
-from rdkit.Chem import MolFromSmiles, MolToSmiles
 
 df = pyrfume.load_data("thresholds/parsed_threshold_data_in_air.csv")
 df = df.set_index("canonical SMILES")

--- a/notebooks/thresholds-add-cids.py
+++ b/notebooks/thresholds-add-cids.py
@@ -16,9 +16,10 @@
 # # Add CIDS to parsed_threshold_data_in_air.csv
 
 import pandas as pd
+from rickpy import ProgressBar
+
 import pyrfume
 from pyrfume.odorants import get_cid, get_cids
-from rickpy import ProgressBar
 
 df = pyrfume.load_data("thresholds/parsed_threshold_data_in_air.csv")
 df = df.set_index("canonical SMILES")

--- a/notebooks/toxicity.py
+++ b/notebooks/toxicity.py
@@ -19,7 +19,7 @@ import pandas as pd
 from rickpy import ProgressBar
 
 import pyrfume
-from pyrfume.pubchem import GHS_CODES, get_ghs_classification, parse_ghs_classification_for_odor
+from pyrfume.pubchem import get_ghs_classification, parse_ghs_classification_for_odor
 
 path = "odorants/all_cids_properties.csv"
 details = pyrfume.load_data(path, usecols=range(5))

--- a/notebooks/toxicity.py
+++ b/notebooks/toxicity.py
@@ -20,35 +20,38 @@ import pyrfume
 from pyrfume.pubchem import get_ghs_classification, parse_ghs_classification_for_odor, GHS_CODES
 from rickpy import ProgressBar
 
-path = 'odorants/all_cids_properties.csv'
+path = "odorants/all_cids_properties.csv"
 details = pyrfume.load_data(path, usecols=range(5))
 details.head()
 
 # ### Cramer Toxicity Class Predictions
 
-tox = pyrfume.load_data('odorants/toxTree.csv')
-cramer = details.join(tox, on='SMILES')['Cramer Class']
-cramer = cramer.apply(lambda x: len(x.split(' ')[-1][:-1]))
+tox = pyrfume.load_data("odorants/toxTree.csv")
+cramer = details.join(tox, on="SMILES")["Cramer Class"]
+cramer = cramer.apply(lambda x: len(x.split(" ")[-1][:-1]))
 cramer.head()
 
-pyrfume.save_data(cramer.to_frame(), 'odorants/cramer.csv')
+pyrfume.save_data(cramer.to_frame(), "odorants/cramer.csv")
 
-embedded_coords = {key: pyrfume.load_data('odorants/%s_umap.pkl' % key) for key in ('snitz', 'haddad')}
+embedded_coords = {
+    key: pyrfume.load_data("odorants/%s_umap.pkl" % key) for key in ("snitz", "haddad")
+}
 
 
 # +
 def plot_tox(space, ax):
     coords = embedded_coords[space].join(cramer)
-    color_dict = {1:'gray', 2:'green', 3:'red'}
-    colors = [color_dict[n] for n in coords['Cramer Class']]
-    ax.scatter(*coords[['X', 'Y']].values.T, color=colors, s=0.5, alpha=0.5);
-    
+    color_dict = {1: "gray", 2: "green", 3: "red"}
+    colors = [color_dict[n] for n in coords["Cramer Class"]]
+    ax.scatter(*coords[["X", "Y"]].values.T, color=colors, s=0.5, alpha=0.5)
+
+
 fig, ax = plt.subplots(1, 2, figsize=(20, 10))
-for i, space in enumerate(('snitz', 'haddad')):
+for i, space in enumerate(("snitz", "haddad")):
     plot_tox(space, ax[i])
     ax[i].set_title(space)
-plt.suptitle('Cramer Class Toxicity: Red=III, Green=II, Gray=I')
-plt.savefig('tox.png', dpi=400)
+plt.suptitle("Cramer Class Toxicity: Red=III, Green=II, Gray=I")
+plt.savefig("tox.png", dpi=400)
 # -
 
 # ### Empirical Toxicity Information
@@ -60,30 +63,32 @@ p = ProgressBar(n_odorants)
 for i, CID in enumerate(details.index):
     p.animate(i)
     ghs_info = get_ghs_classification(CID)
-    strings = parse_ghs_classification_for_odor(ghs_info,
-                                                codes=['H330', 'H331', 'H334', 'H340', 'H350', 'H350i', 'H351', 'H36', 'H37'],
-                                                only_percent=True,
-                                                code_only=True)
+    strings = parse_ghs_classification_for_odor(
+        ghs_info,
+        codes=["H330", "H331", "H334", "H340", "H350", "H350i", "H351", "H36", "H37"],
+        only_percent=True,
+        code_only=True,
+    )
     if strings:
         tox_dict[CID] = strings
 
 # Reformat into a dataframe
-df_tox = pd.DataFrame(columns=['CID', 'Code', '%'])
+df_tox = pd.DataFrame(columns=["CID", "Code", "%"])
 index = 0
 for cid, info in tox_dict.items():
     for x in info:
-        code, other = x.split(' ')
+        code, other = x.split(" ")
         num = float(other[1:-2])
-        #print(cid, code, num)
+        # print(cid, code, num)
         df_tox.loc[index] = [cid, code, num]
         index += 1
 df_tox
 
 empirical_tox = details.copy()
-for key, value in df_tox.groupby(['CID', 'Code']).mean()['%'].items():
+for key, value in df_tox.groupby(["CID", "Code"]).mean()["%"].items():
     cid, code = key
     empirical_tox.loc[cid, code] = value
 empirical_tox = empirical_tox.fillna(0)
 empirical_tox.head()
 
-pyrfume.save_data(empirical_tox, 'odorants/hcode_tox.csv')
+pyrfume.save_data(empirical_tox, "odorants/hcode_tox.csv")

--- a/notebooks/toxicity.py
+++ b/notebooks/toxicity.py
@@ -16,9 +16,10 @@
 # %matplotlib inline
 import matplotlib.pyplot as plt
 import pandas as pd
-import pyrfume
-from pyrfume.pubchem import get_ghs_classification, parse_ghs_classification_for_odor, GHS_CODES
 from rickpy import ProgressBar
+
+import pyrfume
+from pyrfume.pubchem import GHS_CODES, get_ghs_classification, parse_ghs_classification_for_odor
 
 path = "odorants/all_cids_properties.csv"
 details = pyrfume.load_data(path, usecols=range(5))

--- a/notebooks/wachowiak.py
+++ b/notebooks/wachowiak.py
@@ -14,8 +14,6 @@
 # ---
 
 import holoviews as hv
-import hvplot.pandas
-# +
 import numpy as np
 import pandas as pd
 import panel as pn

--- a/notebooks/wachowiak.py
+++ b/notebooks/wachowiak.py
@@ -13,14 +13,14 @@
 #     name: python3
 # ---
 
+import holoviews as hv
+import hvplot.pandas
 # +
 import numpy as np
 import pandas as pd
-import holoviews as hv
-import hvplot.pandas
+import panel as pn
 import param
 from holoviews.selection import link_selections
-import panel as pn
 
 n = 25
 data = {

--- a/notebooks/wachowiak.py
+++ b/notebooks/wachowiak.py
@@ -23,24 +23,29 @@ from holoviews.selection import link_selections
 import panel as pn
 
 n = 25
-data = {"Name": ["Glom %d" % i for i in range(1, n+1)],
-        "x": np.random.randn(n).round(2), "y": np.random.randn(n).round(2),
-        "dF/F": np.random.randint(10, 100, size=n),
-        "Odorant": np.random.randint(10, 100, size=n),
-        "-Log(C)": np.random.uniform(3, 12, size=n).round(2)}
-df = pd.DataFrame(data)#.set_index('Name')
-#df = pd.DataFrame(np.random.randint(10, 100, size=(25, 3)), columns=['x', 'y', 'z'])
+data = {
+    "Name": ["Glom %d" % i for i in range(1, n + 1)],
+    "x": np.random.randn(n).round(2),
+    "y": np.random.randn(n).round(2),
+    "dF/F": np.random.randint(10, 100, size=n),
+    "Odorant": np.random.randint(10, 100, size=n),
+    "-Log(C)": np.random.uniform(3, 12, size=n).round(2),
+}
+df = pd.DataFrame(data)  # .set_index('Name')
+# df = pd.DataFrame(np.random.randint(10, 100, size=(25, 3)), columns=['x', 'y', 'z'])
 scatter = df.hvplot.scatter(x="x", y="y", size="dF/F").opts(height=300, width=300)
 bars = df.hvplot.bar(x="Name", y="-Log(C)").opts(width=300, xrotation=70)
 link = link_selections.instance()
-plots = link(scatter+bars)
+plots = link(scatter + bars)
+
 
 @param.depends(link.param.selection_expr)
 def selection_table(_):
     return hv.Table(hv.Dataset(df).select(link.selection_expr)).opts(width=600, height=200)
 
+
 app = pn.Column(plots, selection_table, height=600)
 app
 # -
 
-app.show(port=8951, websocket_origin=['spike.asu.edu:8952'])
+app.show(port=8951, websocket_origin=["spike.asu.edu:8952"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,7 +15,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "async-generator"
+name = "async_generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
 category = "dev"
@@ -31,10 +31,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "backcall"
@@ -46,7 +46,7 @@ python-versions = "*"
 
 [[package]]
 name = "black"
-version = "22.6.0"
+version = "22.8.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -83,7 +83,7 @@ webencodings = "*"
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.6.15.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -125,7 +125,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "cloudpickle"
-version = "2.1.0"
+version = "2.2.0"
 description = "Extended pickling support for Python objects"
 category = "main"
 optional = true
@@ -141,7 +141,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "cryptography"
-version = "37.0.4"
+version = "38.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -152,11 +152,11 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-sdist = ["setuptools_rust (>=0.11.4)"]
+sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
 name = "cycler"
@@ -183,9 +183,9 @@ toolz = {version = ">=0.8.2", optional = true, markers = "extra == \"bag\""}
 
 [package.extras]
 array = ["numpy (>=1.15.1)", "toolz (>=0.8.2)"]
-bag = ["cloudpickle (>=0.2.2)", "fsspec (>=0.6.0)", "toolz (>=0.8.2)", "partd (>=0.3.10)"]
+bag = ["cloudpickle (>=0.2.2)", "fsspec (>=0.6.0)", "partd (>=0.3.10)", "toolz (>=0.8.2)"]
 complete = ["bokeh (>=1.0.0,!=2.0.0)", "cloudpickle (>=0.2.2)", "distributed (>=2021.03.0)", "fsspec (>=0.6.0)", "numpy (>=1.15.1)", "pandas (>=0.25.0)", "partd (>=0.3.10)", "toolz (>=0.8.2)"]
-dataframe = ["numpy (>=1.15.1)", "pandas (>=0.25.0)", "toolz (>=0.8.2)", "partd (>=0.3.10)", "fsspec (>=0.6.0)"]
+dataframe = ["fsspec (>=0.6.0)", "numpy (>=1.15.1)", "pandas (>=0.25.0)", "partd (>=0.3.10)", "toolz (>=0.8.2)"]
 delayed = ["cloudpickle (>=0.2.2)", "toolz (>=0.8.2)"]
 diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
 distributed = ["distributed (>=2021.03.0)"]
@@ -302,7 +302,7 @@ pycodestyle = ">=2.9.0,<2.10.0"
 pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
-name = "flask"
+name = "Flask"
 version = "2.0.3"
 description = "A simple framework for building complex web applications."
 category = "main"
@@ -332,7 +332,7 @@ abfs = ["adlfs"]
 adl = ["adlfs"]
 arrow = ["pyarrow (>=1)"]
 dask = ["dask", "distributed"]
-dropbox = ["dropboxdrivefs", "requests", "dropbox"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
 entrypoints = ["importlib-metadata"]
 fuse = ["fusepy"]
 gcs = ["gcsfs"]
@@ -341,7 +341,7 @@ github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow (>=1)"]
-http = ["requests", "aiohttp"]
+http = ["aiohttp", "requests"]
 libarchive = ["libarchive-c"]
 oci = ["ocifs"]
 s3 = ["s3fs"]
@@ -378,8 +378,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl-flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "importlib-resources"
@@ -393,8 +393,8 @@ python-versions = ">=3.6"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "ipykernel"
@@ -413,7 +413,7 @@ tornado = ">=4.2"
 traitlets = ">=4.1.0"
 
 [package.extras]
-test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "nose", "jedi (<=0.17.2)"]
+test = ["flaky", "jedi (<=0.17.2)", "nose", "pytest (!=5.3.4)", "pytest-cov"]
 
 [[package]]
 name = "ipython"
@@ -442,13 +442,13 @@ doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
 nbformat = ["nbformat"]
-notebook = ["notebook", "ipywidgets"]
+notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.14)"]
+test = ["ipykernel", "nbformat", "nose (>=0.10.1)", "numpy (>=1.14)", "pygments", "requests", "testpath"]
 
 [[package]]
-name = "ipython-genutils"
+name = "ipython_genutils"
 version = "0.2.0"
 description = "Vestigial utilities from IPython"
 category = "main"
@@ -464,10 +464,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "itsdangerous"
@@ -493,7 +493,7 @@ qa = ["flake8 (==3.7.9)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
 
 [[package]]
-name = "jinja2"
+name = "Jinja2"
 version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "main"
@@ -516,7 +516,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "jsonschema"
-version = "4.0.0"
+version = "3.2.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -525,11 +525,13 @@ python-versions = "*"
 [package.dependencies]
 attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+pyrsistent = ">=0.14.0"
+setuptools = "*"
+six = ">=1.11.0"
 
 [package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format_nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
+format_nongpl = ["idna", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "webcolors"]
 
 [[package]]
 name = "jupyter-client"
@@ -550,7 +552,7 @@ traitlets = "*"
 
 [package.extras]
 doc = ["myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["codecov", "coverage", "ipykernel", "ipython", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "jedi (<0.18)"]
+test = ["codecov", "coverage", "ipykernel", "ipython", "jedi (<0.18)", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-core"
@@ -592,7 +594,7 @@ optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "markupsafe"
+name = "MarkupSafe"
 version = "2.0.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
@@ -668,8 +670,8 @@ optional = false
 python-versions = "*"
 
 [package.extras]
+develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
 tests = ["pytest (>=4.6)"]
-develop = ["wheel", "codecov", "pytest-cov", "pycodestyle", "pytest (>=4.6)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -695,9 +697,9 @@ nest-asyncio = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-dev = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
-sphinx = ["Sphinx (>=1.7)", "sphinx-book-theme", "mock", "moto", "myst-parser"]
-test = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
+dev = ["black", "check-manifest", "codecov", "coverage", "flake8", "ipykernel", "ipython", "ipywidgets", "mypy", "pip (>=18.1)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "setuptools (>=38.6.0)", "tox", "twine (>=1.11.0)", "wheel (>=0.31.0)", "xmltodict"]
+sphinx = ["Sphinx (>=1.7)", "mock", "moto", "myst-parser", "sphinx-book-theme"]
+test = ["black", "check-manifest", "codecov", "coverage", "flake8", "ipykernel", "ipython", "ipywidgets", "mypy", "pip (>=18.1)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "setuptools (>=38.6.0)", "tox", "twine (>=1.11.0)", "wheel (>=0.31.0)", "xmltodict"]
 
 [[package]]
 name = "nbconvert"
@@ -723,10 +725,10 @@ testpath = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)", "tornado (>=4.0)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
-docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+all = ["ipykernel", "ipython", "ipywidgets (>=7)", "nbsphinx (>=0.2.12)", "pyppeteer (==0.2.2)", "pytest", "pytest-cov", "pytest-dependency", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "tornado (>=4.0)"]
+docs = ["ipython", "nbsphinx (>=0.2.12)", "sphinx (>=1.5.1)", "sphinx-rtd-theme"]
 serve = ["tornado (>=4.0)"]
-test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)"]
+test = ["ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)", "pytest", "pytest-cov", "pytest-dependency"]
 webpdf = ["pyppeteer (==0.2.2)"]
 
 [[package]]
@@ -745,7 +747,7 @@ traitlets = ">=4.1"
 
 [package.extras]
 fast = ["fastjsonschema"]
-test = ["check-manifest", "fastjsonschema", "testpath", "pytest", "pytest-cov"]
+test = ["check-manifest", "fastjsonschema", "pytest", "pytest-cov", "testpath"]
 
 [[package]]
 name = "nest-asyncio"
@@ -767,7 +769,7 @@ python-versions = ">=3.6"
 decorator = ">=4.3,<5"
 
 [package.extras]
-all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "lxml", "pytest"]
+all = ["lxml", "matplotlib", "numpy", "pandas", "pydot", "pygraphviz", "pytest", "pyyaml", "scipy"]
 gdal = ["gdal"]
 lxml = ["lxml"]
 matplotlib = ["matplotlib"]
@@ -826,7 +828,7 @@ python-dateutil = ">=2.6.1"
 pytz = ">=2017.2"
 
 [package.extras]
-test = ["hypothesis (>=3.58)", "pytest-xdist", "pytest (>=4.0.2)"]
+test = ["hypothesis (>=3.58)", "pytest (>=4.0.2)", "pytest-xdist"]
 
 [[package]]
 name = "pandocfilters"
@@ -845,7 +847,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-testing = ["pytest (>=3.0.7)", "docopt"]
+testing = ["docopt", "pytest (>=3.0.7)"]
 
 [[package]]
 name = "partd"
@@ -860,7 +862,7 @@ locket = "*"
 toolz = "*"
 
 [package.extras]
-complete = ["blosc", "pyzmq", "pandas (>=0.19.0)", "numpy (>=1.9.0)"]
+complete = ["blosc", "numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq"]
 
 [[package]]
 name = "pathspec"
@@ -890,7 +892,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pillow"
+name = "Pillow"
 version = "8.4.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
@@ -922,7 +924,7 @@ tenacity = ">=6.2.0"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.30"
+version = "3.0.31"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -940,7 +942,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pubchempy"
+name = "PubChemPy"
 version = "1.0.4"
 description = "A simple Python wrapper around the PubChem PUG REST API."
 category = "main"
@@ -994,7 +996,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "pygments"
+name = "Pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
@@ -1005,7 +1007,7 @@ python-versions = ">=3.6"
 plugins = ["importlib-metadata"]
 
 [[package]]
-name = "pymysql"
+name = "PyMySQL"
 version = "1.0.2"
 description = "Pure Python MySQL Driver"
 category = "main"
@@ -1013,8 +1015,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-rsa = ["cryptography"]
 ed25519 = ["PyNaCl (>=1.4.0)"]
+rsa = ["cryptography"]
 
 [[package]]
 name = "pyparsing"
@@ -1063,7 +1065,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pyyaml"
+name = "PyYAML"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -1135,10 +1137,10 @@ scipy = ">=0.19.1"
 threadpoolctl = ">=2.0.0"
 
 [package.extras]
-benchmark = ["matplotlib (>=2.1.1)", "pandas (>=0.25.0)", "memory-profiler (>=0.57.0)"]
-docs = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=3.2.0)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.0.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)"]
-examples = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)"]
-tests = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "mypy (>=0.770)", "pyamg (>=4.0.0)"]
+benchmark = ["matplotlib (>=2.1.1)", "memory-profiler (>=0.57.0)", "pandas (>=0.25.0)"]
+docs = ["Pillow (>=7.1.2)", "matplotlib (>=2.1.1)", "memory-profiler (>=0.57.0)", "numpydoc (>=1.0.0)", "pandas (>=0.25.0)", "scikit-image (>=0.13)", "seaborn (>=0.9.0)", "sphinx (>=3.2.0)", "sphinx-gallery (>=0.7.0)", "sphinx-prompt (>=1.3.0)"]
+examples = ["matplotlib (>=2.1.1)", "pandas (>=0.25.0)", "scikit-image (>=0.13)", "seaborn (>=0.9.0)"]
+tests = ["flake8 (>=3.8.2)", "matplotlib (>=2.1.1)", "mypy (>=0.770)", "pandas (>=0.25.0)", "pyamg (>=4.0.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "scikit-image (>=0.13)"]
 
 [[package]]
 name = "scipy"
@@ -1160,8 +1162,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-inline-tabs", "sphinxcontrib-towncrier", "furo"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "pytest-virtualenv (>=1.2.7)", "wheel", "paver", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "sphinx", "jaraco.path (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
+testing = ["flake8-2020", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1246,7 +1248,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "tqdm"
-version = "4.64.0"
+version = "4.64.1"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
@@ -1276,7 +1278,7 @@ ipython-genutils = "*"
 six = "*"
 
 [package.extras]
-test = ["pytest", "mock"]
+test = ["mock", "pytest"]
 
 [[package]]
 name = "typed-ast"
@@ -1303,8 +1305,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -1335,7 +1337,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "werkzeug"
+name = "Werkzeug"
 version = "2.0.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
@@ -1357,8 +1359,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco-itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [extras]
 optimize = ["dask", "deap"]
@@ -1377,7 +1379,7 @@ appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
 ]
-async-generator = [
+async_generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
     {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
 ]
@@ -1390,37 +1392,37 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 black = [
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
-    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
-    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
-    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
-    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
-    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
-    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
-    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
-    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
-    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
-    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
-    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
-    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
-    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
-    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
-    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
-    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
-    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27"},
+    {file = "black-22.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747"},
+    {file = "black-22.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869"},
+    {file = "black-22.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90"},
+    {file = "black-22.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe"},
+    {file = "black-22.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342"},
+    {file = "black-22.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab"},
+    {file = "black-22.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3"},
+    {file = "black-22.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e"},
+    {file = "black-22.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5"},
+    {file = "black-22.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411"},
+    {file = "black-22.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3"},
+    {file = "black-22.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497"},
+    {file = "black-22.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c"},
+    {file = "black-22.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41"},
+    {file = "black-22.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec"},
+    {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
+    {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
 bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
+    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
@@ -1497,36 +1499,40 @@ click = [
     {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 cloudpickle = [
-    {file = "cloudpickle-2.1.0-py3-none-any.whl", hash = "sha256:b5c434f75c34624eedad3a14f2be5ac3b5384774d5b0e3caf905c21479e6c4b1"},
-    {file = "cloudpickle-2.1.0.tar.gz", hash = "sha256:bb233e876a58491d9590a676f93c7a5473a08f747d5ab9df7f9ce564b3e7938e"},
+    {file = "cloudpickle-2.2.0-py3-none-any.whl", hash = "sha256:7428798d5926d8fcbfd092d18d01a2a03daf8237d8fcdc8095d256b8490796f0"},
+    {file = "cloudpickle-2.2.0.tar.gz", hash = "sha256:3f4219469c55453cfe4737e564b67c2a149109dabf7f242478948b895f61106f"},
 ]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 cryptography = [
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884"},
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59"},
-    {file = "cryptography-37.0.4-cp36-abi3-win32.whl", hash = "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157"},
-    {file = "cryptography-37.0.4-cp36-abi3-win_amd64.whl", hash = "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab"},
-    {file = "cryptography-37.0.4.tar.gz", hash = "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82"},
+    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f"},
+    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd"},
+    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6"},
+    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a"},
+    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294"},
+    {file = "cryptography-38.0.1-cp36-abi3-win32.whl", hash = "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0"},
+    {file = "cryptography-38.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9"},
+    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013"},
+    {file = "cryptography-38.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a"},
+    {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
+    {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
 ]
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
@@ -1590,7 +1596,7 @@ flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
-flask = [
+Flask = [
     {file = "Flask-2.0.3-py3-none-any.whl", hash = "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"},
     {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
 ]
@@ -1621,7 +1627,7 @@ ipython = [
     {file = "ipython-7.16.3-py3-none-any.whl", hash = "sha256:c0427ed8bc33ac481faf9d3acf7e84e0010cdaada945e0badd1e2e74cc075833"},
     {file = "ipython-7.16.3.tar.gz", hash = "sha256:5ac47dc9af66fc2f5530c12069390877ae372ac905edca75a92a6e363b5d7caa"},
 ]
-ipython-genutils = [
+ipython_genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
@@ -1637,7 +1643,7 @@ jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
     {file = "jedi-0.17.2.tar.gz", hash = "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20"},
 ]
-jinja2 = [
+Jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
@@ -1646,8 +1652,8 @@ joblib = [
     {file = "joblib-1.1.0.tar.gz", hash = "sha256:4158fcecd13733f8be669be0683b96ebdbbd38d23559f54dca7205aea1bf1e35"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.0.0-py3-none-any.whl", hash = "sha256:c773028c649441ab980015b5b622f4cd5134cf563daaf0235ca4b73cc3734f20"},
-    {file = "jsonschema-4.0.0.tar.gz", hash = "sha256:bc51325b929171791c42ebc1c70b9713eb134d3bb8ebd5474c8b659b15be6d86"},
+    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
+    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
 jupyter-client = [
     {file = "jupyter_client-7.1.2-py3-none-any.whl", hash = "sha256:d56f1c57bef42ff31e61b1185d3348a5b2bcde7c9a05523ae4dbe5ee0871797c"},
@@ -1704,7 +1710,7 @@ locket = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
-markupsafe = [
+MarkupSafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
@@ -1931,7 +1937,7 @@ pickleshare = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
-pillow = [
+Pillow = [
     {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
     {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
     {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
@@ -1983,14 +1989,14 @@ plotly = [
     {file = "plotly-5.10.0.tar.gz", hash = "sha256:4d36d9859b7a153b273562deeed8c292587a472eb1fd57cd4158ec89d9defadb"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.30-py3-none-any.whl", hash = "sha256:d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289"},
-    {file = "prompt_toolkit-3.0.30.tar.gz", hash = "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0"},
+    {file = "prompt_toolkit-3.0.31-py3-none-any.whl", hash = "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d"},
+    {file = "prompt_toolkit-3.0.31.tar.gz", hash = "sha256:9ada952c9d1787f52ff6d5f3484d0b4df8952787c087edf6a1f7c2cb1ea88148"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-pubchempy = [
+PubChemPy = [
     {file = "PubChemPy-1.0.4.tar.gz", hash = "sha256:24e9dc2fc90ab153b2764bf805e510b1410700884faf0510a9e7cf0d61d8ed0e"},
 ]
 py = [
@@ -2013,11 +2019,11 @@ pyflakes = [
     {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
     {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
-pygments = [
+Pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
     {file = "Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
 ]
-pymysql = [
+PyMySQL = [
     {file = "PyMySQL-1.0.2-py3-none-any.whl", hash = "sha256:41fc3a0c5013d5f039639442321185532e3e2c8924687abe6537de157d403641"},
     {file = "PyMySQL-1.0.2.tar.gz", hash = "sha256:816927a350f38d56072aeca5dfb10221fe1dc653745853d30a216637f5d7ad36"},
 ]
@@ -2072,7 +2078,7 @@ pywin32 = [
     {file = "pywin32-304-cp39-cp39-win32.whl", hash = "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc"},
     {file = "pywin32-304-cp39-cp39-win_amd64.whl", hash = "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9"},
 ]
-pyyaml = [
+PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -2146,6 +2152,7 @@ pyzmq = [
     {file = "pyzmq-23.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:48400b96788cdaca647021bf19a9cd668384f46e4d9c55cf045bdd17f65299c8"},
     {file = "pyzmq-23.2.1-cp37-cp37m-win32.whl", hash = "sha256:8a68f57b7a3f7b6b52ada79876be1efb97c8c0952423436e84d70cc139f16f0d"},
     {file = "pyzmq-23.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9e5bf6e7239fc9687239de7a283aa8b801ab85371116045b33ae20132a1325d6"},
+    {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:0ff6294e001129a9f22dcbfba186165c7e6f573c46de2704d76f873c94c65416"},
     {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffc6b1623d0f9affb351db4ca61f432dca3628a5ee015f9bf2bfbe9c6836881c"},
     {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d6f110c56f7d5b4d64dde3a382ae61b6d48174e30742859d8e971b18b6c9e5c"},
     {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9269fbfe3a4eb2009199120861c4571ef1655fdf6951c3e7f233567c94e8c602"},
@@ -2352,8 +2359,8 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 tqdm = [
-    {file = "tqdm-4.64.0-py2.py3-none-any.whl", hash = "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"},
-    {file = "tqdm-4.64.0.tar.gz", hash = "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d"},
+    {file = "tqdm-4.64.1-py2.py3-none-any.whl", hash = "sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1"},
+    {file = "tqdm-4.64.1.tar.gz", hash = "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"},
 ]
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
@@ -2428,7 +2435,7 @@ webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
-werkzeug = [
+Werkzeug = [
     {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},
     {file = "Werkzeug-2.0.3.tar.gz", hash = "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,14 +15,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "async_generator"
-version = "1.10"
-description = "Async generators and context managers for Python 3.5+"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -45,6 +37,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "22.8.0"
 description = "The uncompromising code formatter."
@@ -54,7 +61,6 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 click = ">=8.0.0"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
@@ -70,20 +76,23 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleach"
-version = "4.1.0"
+version = "5.0.1"
 description = "An easy safelist-based HTML-sanitizing tool."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-packaging = "*"
 six = ">=1.9.0"
 webencodings = "*"
 
+[package.extras]
+css = ["tinycss2 (>=1.1.0,<1.2)"]
+dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "mypy (==0.961)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)"]
+
 [[package]]
 name = "certifi"
-version = "2022.6.15.1"
+version = "2022.9.14"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -113,11 +122,11 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.4"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -191,14 +200,6 @@ diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
 distributed = ["distributed (>=2021.03.0)"]
 
 [[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = ">=3.6, <3.7"
-
-[[package]]
 name = "datajoint"
 version = "0.13.4"
 description = "A relational data pipeline framework."
@@ -233,12 +234,20 @@ python-versions = "*"
 numpy = "*"
 
 [[package]]
+name = "debugpy"
+version = "1.6.3"
+description = "An implementation of the Debug Adapter Protocol for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "decorator"
-version = "4.4.2"
+version = "5.1.1"
 description = "Decorators for Humans"
 category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "defusedxml"
@@ -250,11 +259,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "dill"
-version = "0.3.4"
+version = "0.3.5.1"
 description = "serialize all of python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 
 [package.extras]
 graph = ["objgraph (>=1.7.2)"]
@@ -288,6 +297,17 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "fastjsonschema"
+version = "2.16.1"
+description = "Fastest Python implementation of JSON schema"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
+
+[[package]]
 name = "flake8"
 version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -303,29 +323,52 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "Flask"
-version = "2.0.3"
+version = "2.2.2"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-click = ">=7.1.2"
+click = ">=8.0"
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.0"
 Jinja2 = ">=3.0"
-Werkzeug = ">=2.0"
+Werkzeug = ">=2.2.2"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
 
 [[package]]
+name = "fonttools"
+version = "4.37.2"
+description = "Tools to manipulate font files"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=14.0.0)", "xattr", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres", "scipy"]
+lxml = ["lxml (>=4.0,<5)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.23.0)"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=14.0.0)"]
+woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
+
+[[package]]
 name = "fsspec"
-version = "2022.1.0"
+version = "2022.8.2"
 description = "File-system specification"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 abfs = ["adlfs"]
@@ -341,13 +384,14 @@ github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow (>=1)"]
-http = ["aiohttp", "requests"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "requests"]
 libarchive = ["libarchive-c"]
 oci = ["ocifs"]
 s3 = ["s3fs"]
 sftp = ["paramiko"]
 smb = ["smbprotocol"]
 ssh = ["paramiko"]
+tqdm = ["tqdm"]
 
 [[package]]
 name = "future"
@@ -359,7 +403,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -383,53 +427,59 @@ testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517",
 
 [[package]]
 name = "importlib-resources"
-version = "5.4.0"
+version = "5.9.0"
 description = "Read resources from Python packages"
-category = "main"
+category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "ipykernel"
-version = "5.5.6"
+version = "6.15.0"
 description = "IPython Kernel for Jupyter"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
 appnope = {version = "*", markers = "platform_system == \"Darwin\""}
-ipython = ">=5.0.0"
-ipython-genutils = "*"
-jupyter-client = "*"
-tornado = ">=4.2"
-traitlets = ">=4.1.0"
+debugpy = ">=1.0"
+ipython = ">=7.23.1"
+jupyter-client = ">=6.1.12"
+matplotlib-inline = ">=0.1"
+nest-asyncio = "*"
+packaging = "*"
+psutil = "*"
+pyzmq = ">=17"
+tornado = ">=6.1"
+traitlets = ">=5.1.0"
 
 [package.extras]
-test = ["flaky", "jedi (<=0.17.2)", "nose", "pytest (!=5.3.4)", "pytest-cov"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=6.0)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "ipython"
-version = "7.16.3"
+version = "7.34.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 appnope = {version = "*", markers = "sys_platform == \"darwin\""}
 backcall = "*"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
-jedi = ">=0.10,<=0.17.2"
-pexpect = {version = "*", markers = "sys_platform != \"win32\""}
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = "*"
@@ -437,7 +487,7 @@ setuptools = ">=18.5"
 traitlets = ">=4.2"
 
 [package.extras]
-all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.14)", "pygments", "qtconsole", "requests", "testpath"]
+all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.17)", "pygments", "qtconsole", "requests", "testpath"]
 doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
@@ -445,15 +495,7 @@ nbformat = ["nbformat"]
 notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["ipykernel", "nbformat", "nose (>=0.10.1)", "numpy (>=1.14)", "pygments", "requests", "testpath"]
-
-[[package]]
-name = "ipython_genutils"
-version = "0.2.0"
-description = "Vestigial utilities from IPython"
-category = "main"
-optional = false
-python-versions = "*"
+test = ["ipykernel", "nbformat", "nose (>=0.10.1)", "numpy (>=1.17)", "pygments", "requests", "testpath"]
 
 [[package]]
 name = "isort"
@@ -471,34 +513,34 @@ requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "itsdangerous"
-version = "2.0.1"
+version = "2.1.2"
 description = "Safely pass data to untrusted environments and back."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "jedi"
-version = "0.17.2"
+version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-parso = ">=0.7.0,<0.8.0"
+parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
-qa = ["flake8 (==3.7.9)"]
-testing = ["Django (<3.1)", "colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "Jinja2"
-version = "3.0.3"
+version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 MarkupSafe = ">=2.0"
@@ -516,74 +558,78 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "jsonschema"
-version = "3.2.0"
+version = "4.16.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-pyrsistent = ">=0.14.0"
-setuptools = "*"
-six = ">=1.11.0"
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
-format_nongpl = ["idna", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "webcolors"]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
 name = "jupyter-client"
-version = "7.1.2"
+version = "7.3.5"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7"
 
 [package.dependencies]
 entrypoints = "*"
-jupyter-core = ">=4.6.0"
-nest-asyncio = ">=1.5"
-python-dateutil = ">=2.1"
-pyzmq = ">=13"
-tornado = ">=4.1"
+jupyter-core = ">=4.9.2"
+nest-asyncio = ">=1.5.4"
+python-dateutil = ">=2.8.2"
+pyzmq = ">=23.0"
+tornado = ">=6.2"
 traitlets = "*"
 
 [package.extras]
-doc = ["myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["codecov", "coverage", "ipykernel", "ipython", "jedi (<0.18)", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout"]
+doc = ["ipykernel", "myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-core"
-version = "4.9.2"
+version = "4.11.1"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
 traitlets = "*"
 
+[package.extras]
+test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
+
 [[package]]
 name = "jupyterlab-pygments"
-version = "0.1.2"
+version = "0.2.2"
 description = "Pygments theme using JupyterLab CSS variables"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-pygments = ">=2.4.1,<3"
+python-versions = ">=3.7"
 
 [[package]]
 name = "kiwisolver"
-version = "1.3.1"
+version = "1.4.4"
 description = "A fast implementation of the Cassowary constraint solver"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "locket"
@@ -595,27 +641,41 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "MarkupSafe"
-version = "2.0.1"
+version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "matplotlib"
-version = "3.3.4"
+version = "3.5.3"
 description = "Python plotting package"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 cycler = ">=0.10"
+fonttools = ">=4.22.0"
 kiwisolver = ">=1.0.1"
-numpy = ">=1.15"
+numpy = ">=1.17"
+packaging = ">=20.0"
 pillow = ">=6.2.0"
-pyparsing = ">=2.0.3,<2.0.4 || >2.0.4,<2.1.2 || >2.1.2,<2.1.6 || >2.1.6"
-python-dateutil = ">=2.1"
+pyparsing = ">=2.2.1"
+python-dateutil = ">=2.7"
+setuptools_scm = ">=4,<7"
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.6"
+description = "Inline Matplotlib backend for Jupyter"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+traitlets = "*"
 
 [[package]]
 name = "mccabe"
@@ -683,71 +743,70 @@ python-versions = "*"
 
 [[package]]
 name = "nbclient"
-version = "0.5.9"
+version = "0.5.13"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 category = "dev"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7.0"
 
 [package.dependencies]
-async-generator = {version = "*", markers = "python_version < \"3.7\""}
 jupyter-client = ">=6.1.5"
 nbformat = ">=5.0"
 nest-asyncio = "*"
-traitlets = ">=4.2"
+traitlets = ">=5.0.0"
 
 [package.extras]
-dev = ["black", "check-manifest", "codecov", "coverage", "flake8", "ipykernel", "ipython", "ipywidgets", "mypy", "pip (>=18.1)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "setuptools (>=38.6.0)", "tox", "twine (>=1.11.0)", "wheel (>=0.31.0)", "xmltodict"]
 sphinx = ["Sphinx (>=1.7)", "mock", "moto", "myst-parser", "sphinx-book-theme"]
-test = ["black", "check-manifest", "codecov", "coverage", "flake8", "ipykernel", "ipython", "ipywidgets", "mypy", "pip (>=18.1)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "setuptools (>=38.6.0)", "tox", "twine (>=1.11.0)", "wheel (>=0.31.0)", "xmltodict"]
+test = ["black", "check-manifest", "flake8", "ipykernel", "ipython (<8.0.0)", "ipywidgets (<8.0.0)", "mypy", "pip (>=18.1)", "pytest (>=4.1)", "pytest-asyncio", "pytest-cov (>=2.6.1)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "wheel (>=0.31.0)", "xmltodict"]
 
 [[package]]
 name = "nbconvert"
-version = "6.0.7"
+version = "6.4.5"
 description = "Converting Jupyter Notebooks"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
+beautifulsoup4 = "*"
 bleach = "*"
 defusedxml = "*"
 entrypoints = ">=0.2.2"
 jinja2 = ">=2.4"
 jupyter-core = "*"
 jupyterlab-pygments = "*"
+MarkupSafe = ">=2.0"
 mistune = ">=0.8.1,<2"
 nbclient = ">=0.5.0,<0.6.0"
 nbformat = ">=4.4"
 pandocfilters = ">=1.4.1"
 pygments = ">=2.4.1"
 testpath = "*"
-traitlets = ">=4.2"
+traitlets = ">=5.0"
 
 [package.extras]
-all = ["ipykernel", "ipython", "ipywidgets (>=7)", "nbsphinx (>=0.2.12)", "pyppeteer (==0.2.2)", "pytest", "pytest-cov", "pytest-dependency", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "tornado (>=4.0)"]
+all = ["ipykernel", "ipython", "ipywidgets (>=7)", "nbsphinx (>=0.2.12)", "pyppeteer (>=1,<1.1)", "pytest", "pytest-cov", "pytest-dependency", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "tornado (>=4.0)"]
 docs = ["ipython", "nbsphinx (>=0.2.12)", "sphinx (>=1.5.1)", "sphinx-rtd-theme"]
 serve = ["tornado (>=4.0)"]
-test = ["ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)", "pytest", "pytest-cov", "pytest-dependency"]
-webpdf = ["pyppeteer (==0.2.2)"]
+test = ["ipykernel", "ipywidgets (>=7)", "pyppeteer (>=1,<1.1)", "pytest", "pytest-cov", "pytest-dependency"]
+webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
 name = "nbformat"
-version = "5.1.3"
+version = "5.5.0"
 description = "The Jupyter Notebook format"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
-ipython-genutils = "*"
-jsonschema = ">=2.4,<2.5.0 || >2.5.0"
-jupyter-core = "*"
-traitlets = ">=4.1"
+fastjsonschema = "*"
+jsonschema = ">=2.6"
+jupyter_core = "*"
+traitlets = ">=5.1"
 
 [package.extras]
-fast = ["fastjsonschema"]
-test = ["check-manifest", "fastjsonschema", "pytest", "pytest-cov", "testpath"]
+test = ["check-manifest", "pep440", "pre-commit", "pytest", "testpath"]
 
 [[package]]
 name = "nest-asyncio"
@@ -759,35 +818,26 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "networkx"
-version = "2.5.1"
+version = "2.6.3"
 description = "Python package for creating and manipulating graphs and networks"
 category = "main"
 optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-decorator = ">=4.3,<5"
+python-versions = ">=3.7"
 
 [package.extras]
-all = ["lxml", "matplotlib", "numpy", "pandas", "pydot", "pygraphviz", "pytest", "pyyaml", "scipy"]
-gdal = ["gdal"]
-lxml = ["lxml"]
-matplotlib = ["matplotlib"]
-numpy = ["numpy"]
-pandas = ["pandas"]
-pydot = ["pydot"]
-pygraphviz = ["pygraphviz"]
-pytest = ["pytest"]
-pyyaml = ["pyyaml"]
-scipy = ["scipy"]
+default = ["matplotlib (>=3.3)", "numpy (>=1.19)", "pandas (>=1.1)", "scipy (>=1.5,!=1.6.1)"]
+developer = ["black (==21.5b1)", "pre-commit (>=2.12)"]
+doc = ["nb2plots (>=0.6)", "numpydoc (>=1.1)", "pillow (>=8.2)", "pydata-sphinx-theme (>=0.6,<1.0)", "sphinx (>=4.0,<5.0)", "sphinx-gallery (>=0.9,<1.0)", "texext (>=0.6.6)"]
+extra = ["lxml (>=4.5)", "pydot (>=1.4.1)", "pygraphviz (>=1.7)"]
+test = ["codecov (>=2.1)", "pytest (>=6.2)", "pytest-cov (>=2.12)"]
 
 [[package]]
 name = "numpy"
-version = "1.19.5"
+version = "1.20.2"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "otumat"
@@ -807,7 +857,7 @@ watchdog = "*"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -816,15 +866,15 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.0.5"
+version = "1.1.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
-numpy = ">=1.13.3"
-python-dateutil = ">=2.6.1"
+numpy = ">=1.15.4"
+python-dateutil = ">=2.7.3"
 pytz = ">=2017.2"
 
 [package.extras]
@@ -840,22 +890,23 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "parso"
-version = "0.7.1"
+version = "0.8.3"
 description = "A Python Parser"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.extras]
-testing = ["docopt", "pytest (>=3.0.7)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
 name = "partd"
-version = "1.2.0"
+version = "1.3.0"
 description = "Appendable key-value storage"
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
 locket = "*"
@@ -866,11 +917,11 @@ complete = ["blosc", "numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq"]
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pexpect"
@@ -893,22 +944,34 @@ python-versions = "*"
 
 [[package]]
 name = "Pillow"
-version = "8.4.0"
+version = "9.2.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-issues (>=3.0.1)", "sphinx-removed-in", "sphinxext-opengraph"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "pkgutil_resolve_name"
+version = "1.3.10"
+description = "Resolve a name to an object."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
@@ -932,6 +995,17 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "psutil"
+version = "5.9.2"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "ptyprocess"
@@ -1020,22 +1094,22 @@ rsa = ["cryptography"]
 
 [[package]]
 name = "pyparsing"
-version = "3.0.7"
-description = "Python parsing module"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.8"
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
-version = "0.18.0"
+version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "python-dateutil"
@@ -1074,7 +1148,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyzmq"
-version = "23.2.1"
+version = "24.0.0"
 description = "Python bindings for 0MQ"
 category = "main"
 optional = false
@@ -1155,15 +1229,33 @@ numpy = ">=1.14.5"
 
 [[package]]
 name = "setuptools"
-version = "59.6.0"
+version = "65.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "setuptools-scm"
+version = "6.4.2"
+description = "the blessed package to manage your versions by scm tags"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+packaging = ">=20.0"
+setuptools = "*"
+tomli = ">=1.0.0"
+
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
-testing = ["flake8-2020", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+test = ["pytest (>=6.2)", "virtualenv (>20)"]
+toml = ["setuptools (>=42)"]
 
 [[package]]
 name = "six"
@@ -1172,6 +1264,14 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "sympy"
@@ -1224,11 +1324,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.3"
+version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "toolz"
@@ -1240,11 +1340,11 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "tornado"
-version = "6.1"
+version = "6.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 category = "main"
 optional = false
-python-versions = ">= 3.5"
+python-versions = ">= 3.7"
 
 [[package]]
 name = "tqdm"
@@ -1256,7 +1356,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
@@ -1266,19 +1365,14 @@ telegram = ["requests"]
 
 [[package]]
 name = "traitlets"
-version = "4.3.3"
-description = "Traitlets Python config system"
+version = "5.4.0"
+description = ""
 category = "main"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-decorator = "*"
-ipython-genutils = "*"
-six = "*"
+python-versions = ">=3.7"
 
 [package.extras]
-test = ["mock", "pytest"]
+test = ["pre-commit", "pytest"]
 
 [[package]]
 name = "typed-ast"
@@ -1290,11 +1384,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
@@ -1338,37 +1432,37 @@ python-versions = "*"
 
 [[package]]
 name = "Werkzeug"
-version = "2.0.3"
+version = "2.2.2"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
-dataclasses = {version = "*", markers = "python_version < \"3.7\""}
+MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog"]
 
 [[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 optimize = ["dask", "deap"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.2,<4.0"
-content-hash = "5364bf1f0d3f5b997fbd7224fb9baca07763656df9b05ad3d07f34fea79078b2"
+python-versions = ">=3.7,<3.10"
+content-hash = "13e65cdf87e91e5c72daee2a8dcb8e5d35bc09ac8b5c445c42a6a53669383b98"
 
 [metadata.files]
 appdirs = [
@@ -1379,10 +1473,6 @@ appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
 ]
-async_generator = [
-    {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
-    {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
-]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
@@ -1390,6 +1480,10 @@ attrs = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 black = [
     {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
@@ -1417,12 +1511,12 @@ black = [
     {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
 bleach = [
-    {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
-    {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
+    {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
+    {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
-    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
+    {file = "certifi-2022.9.14-py3-none-any.whl", hash = "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"},
+    {file = "certifi-2022.9.14.tar.gz", hash = "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
@@ -1495,8 +1589,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
-    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 cloudpickle = [
     {file = "cloudpickle-2.2.0-py3-none-any.whl", hash = "sha256:7428798d5926d8fcbfd092d18d01a2a03daf8237d8fcdc8095d256b8490796f0"},
@@ -1542,10 +1636,6 @@ dask = [
     {file = "dask-2021.3.0-py3-none-any.whl", hash = "sha256:9943b58215090ec388250c572ba4484b9e0f3e57092c3045871f79e69b3c8658"},
     {file = "dask-2021.3.0.tar.gz", hash = "sha256:566054b493d63c15732f2a640382b21e861571d61639f59341bc7695a9be138e"},
 ]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
-]
 datajoint = [
     {file = "datajoint-0.13.4-py3-none-any.whl", hash = "sha256:cba432a80b1e064402c88a90b55365968b7223255a94c7df2f6edc8742cb4655"},
     {file = "datajoint-0.13.4.tar.gz", hash = "sha256:94cb87b9513eb696de0d76ecaee6533d8574e33182c77caa4f7b067e40ceb477"},
@@ -1573,17 +1663,37 @@ deap = [
     {file = "deap-1.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:00307dfaf693072c289fe06a9b159db4bc1a17b18215466662644ded06aa8d45"},
     {file = "deap-1.3.3.tar.gz", hash = "sha256:8772f1b0fff042d5e516b0aebac2c706243045aa7d0de8e0b8658f380181cf31"},
 ]
+debugpy = [
+    {file = "debugpy-1.6.3-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:c4b2bd5c245eeb49824bf7e539f95fb17f9a756186e51c3e513e32999d8846f3"},
+    {file = "debugpy-1.6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b8deaeb779699350deeed835322730a3efec170b88927debc9ba07a1a38e2585"},
+    {file = "debugpy-1.6.3-cp310-cp310-win32.whl", hash = "sha256:fc233a0160f3b117b20216f1169e7211b83235e3cd6749bcdd8dbb72177030c7"},
+    {file = "debugpy-1.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:dda8652520eae3945833e061cbe2993ad94a0b545aebd62e4e6b80ee616c76b2"},
+    {file = "debugpy-1.6.3-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:d5c814596a170a0a58fa6fad74947e30bfd7e192a5d2d7bd6a12156c2899e13a"},
+    {file = "debugpy-1.6.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c4cd6f37e3c168080d61d698390dfe2cd9e74ebf80b448069822a15dadcda57d"},
+    {file = "debugpy-1.6.3-cp37-cp37m-win32.whl", hash = "sha256:3c9f985944a30cfc9ae4306ac6a27b9c31dba72ca943214dad4a0ab3840f6161"},
+    {file = "debugpy-1.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:5ad571a36cec137ae6ed951d0ff75b5e092e9af6683da084753231150cbc5b25"},
+    {file = "debugpy-1.6.3-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:adcfea5ea06d55d505375995e150c06445e2b20cd12885bcae566148c076636b"},
+    {file = "debugpy-1.6.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:daadab4403427abd090eccb38d8901afd8b393e01fd243048fab3f1d7132abb4"},
+    {file = "debugpy-1.6.3-cp38-cp38-win32.whl", hash = "sha256:6efc30325b68e451118b795eff6fe8488253ca3958251d5158106d9c87581bc6"},
+    {file = "debugpy-1.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:86d784b72c5411c833af1cd45b83d80c252b77c3bfdb43db17c441d772f4c734"},
+    {file = "debugpy-1.6.3-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4e255982552b0edfe3a6264438dbd62d404baa6556a81a88f9420d3ed79b06ae"},
+    {file = "debugpy-1.6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cca23cb6161ac89698d629d892520327dd1be9321c0960e610bbcb807232b45d"},
+    {file = "debugpy-1.6.3-cp39-cp39-win32.whl", hash = "sha256:7c302095a81be0d5c19f6529b600bac971440db3e226dce85347cc27e6a61908"},
+    {file = "debugpy-1.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:34d2cdd3a7c87302ba5322b86e79c32c2115be396f3f09ca13306d8a04fe0f16"},
+    {file = "debugpy-1.6.3-py2.py3-none-any.whl", hash = "sha256:84c39940a0cac410bf6aa4db00ba174f973eef521fbe9dd058e26bcabad89c4f"},
+    {file = "debugpy-1.6.3.zip", hash = "sha256:e8922090514a890eec99cfb991bab872dd2e353ebb793164d5f01c362b9a40bf"},
+]
 decorator = [
-    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
-    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 dill = [
-    {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
-    {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
+    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
+    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 eden-kernel = [
     {file = "eden-kernel-0.3.1348.tar.gz", hash = "sha256:d1346320e950c2d046820834b06754820cc7d2d0965dd53f1ed38143e66c251d"},
@@ -1592,221 +1702,241 @@ entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
+fastjsonschema = [
+    {file = "fastjsonschema-2.16.1-py3-none-any.whl", hash = "sha256:2f7158c4de792555753d6c2277d6a2af2d406dfd97aeca21d17173561ede4fe6"},
+    {file = "fastjsonschema-2.16.1.tar.gz", hash = "sha256:d6fa3ffbe719768d70e298b9fb847484e2bdfdb7241ed052b8d57a9294a8c334"},
+]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
 Flask = [
-    {file = "Flask-2.0.3-py3-none-any.whl", hash = "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"},
-    {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
+    {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
+    {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
+]
+fonttools = [
+    {file = "fonttools-4.37.2-py3-none-any.whl", hash = "sha256:88d48ef24486137c864dc56707b4b54ef8a97ab9162c2721ec61434baf1c4d13"},
+    {file = "fonttools-4.37.2.zip", hash = "sha256:b6d86ffd0a5f83d3da6a34d5f99a90398638e423cd6a8d93c5808af703432c7f"},
 ]
 fsspec = [
-    {file = "fsspec-2022.1.0-py3-none-any.whl", hash = "sha256:256e2be44e62430c9ca8dac2e480384b00a3c52aef4e2b0b7204163fdc861d37"},
-    {file = "fsspec-2022.1.0.tar.gz", hash = "sha256:0bdd519bbf4d8c9a1d893a50b5ebacc89acd0e1fe0045d2f7b0e0c1af5990edc"},
+    {file = "fsspec-2022.8.2-py3-none-any.whl", hash = "sha256:6374804a2c0d24f225a67d009ee1eabb4046ad00c793c3f6df97e426c890a1d9"},
+    {file = "fsspec-2022.8.2.tar.gz", hash = "sha256:7f12b90964a98a7e921d27fb36be536ea036b73bf3b724ac0b0bd7b8e39c7c18"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
     {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
-    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
+    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
+    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
 ]
 ipykernel = [
-    {file = "ipykernel-5.5.6-py3-none-any.whl", hash = "sha256:66f824af1ef4650e1e2f6c42e1423074321440ef79ca3651a6cfd06a4e25e42f"},
-    {file = "ipykernel-5.5.6.tar.gz", hash = "sha256:4ea44b90ae1f7c38987ad58ea0809562a17c2695a0499644326f334aecd369ec"},
+    {file = "ipykernel-6.15.0-py3-none-any.whl", hash = "sha256:b9ed519a29eb819eb82e87e0d3754088237b233e5c647b8bb0ff23c8c70ed16f"},
+    {file = "ipykernel-6.15.0.tar.gz", hash = "sha256:b59f9d9672c3a483494bb75915a2b315e78b833a38b039b1ee36dc28683f0d89"},
 ]
 ipython = [
-    {file = "ipython-7.16.3-py3-none-any.whl", hash = "sha256:c0427ed8bc33ac481faf9d3acf7e84e0010cdaada945e0badd1e2e74cc075833"},
-    {file = "ipython-7.16.3.tar.gz", hash = "sha256:5ac47dc9af66fc2f5530c12069390877ae372ac905edca75a92a6e363b5d7caa"},
-]
-ipython_genutils = [
-    {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
-    {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
+    {file = "ipython-7.34.0-py3-none-any.whl", hash = "sha256:c175d2440a1caff76116eb719d40538fbb316e214eda85c5515c303aacbfb23e"},
+    {file = "ipython-7.34.0.tar.gz", hash = "sha256:af3bdb46aa292bce5615b1b2ebc76c2080c5f77f54bda2ec72461317273e7cd6"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 itsdangerous = [
-    {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
-    {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
+    {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
+    {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
 ]
 jedi = [
-    {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
-    {file = "jedi-0.17.2.tar.gz", hash = "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20"},
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
 Jinja2 = [
-    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
-    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
 joblib = [
     {file = "joblib-1.1.0-py2.py3-none-any.whl", hash = "sha256:f21f109b3c7ff9d95f8387f752d0d9c34a02aa2f7060c2135f465da0e5160ff6"},
     {file = "joblib-1.1.0.tar.gz", hash = "sha256:4158fcecd13733f8be669be0683b96ebdbbd38d23559f54dca7205aea1bf1e35"},
 ]
 jsonschema = [
-    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
-    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+    {file = "jsonschema-4.16.0-py3-none-any.whl", hash = "sha256:9e74b8f9738d6a946d70705dc692b74b5429cd0960d58e79ffecfc43b2221eb9"},
+    {file = "jsonschema-4.16.0.tar.gz", hash = "sha256:165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-7.1.2-py3-none-any.whl", hash = "sha256:d56f1c57bef42ff31e61b1185d3348a5b2bcde7c9a05523ae4dbe5ee0871797c"},
-    {file = "jupyter_client-7.1.2.tar.gz", hash = "sha256:4ea61033726c8e579edb55626d8ee2e6bf0a83158ddf3751b8dd46b2c5cd1e96"},
+    {file = "jupyter_client-7.3.5-py3-none-any.whl", hash = "sha256:b33222bdc9dd1714228bd286af006533a0abe2bbc093e8f3d29dc0b91bdc2be4"},
+    {file = "jupyter_client-7.3.5.tar.gz", hash = "sha256:3c58466a1b8d55dba0bf3ce0834e4f5b7760baf98d1d73db0add6f19de9ecd1d"},
 ]
 jupyter-core = [
-    {file = "jupyter_core-4.9.2-py3-none-any.whl", hash = "sha256:f875e4d27e202590311d468fa55f90c575f201490bd0c18acabe4e318db4a46d"},
-    {file = "jupyter_core-4.9.2.tar.gz", hash = "sha256:d69baeb9ffb128b8cd2657fcf2703f89c769d1673c851812119e3a2a0e93ad9a"},
+    {file = "jupyter_core-4.11.1-py3-none-any.whl", hash = "sha256:715e22bb6cc7db3718fddfac1f69f1c7e899ca00e42bdfd4bf3705452b9fd84a"},
+    {file = "jupyter_core-4.11.1.tar.gz", hash = "sha256:2e5f244d44894c4154d06aeae3419dd7f1b0ef4494dc5584929b398c61cfd314"},
 ]
 jupyterlab-pygments = [
-    {file = "jupyterlab_pygments-0.1.2-py2.py3-none-any.whl", hash = "sha256:abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008"},
-    {file = "jupyterlab_pygments-0.1.2.tar.gz", hash = "sha256:cfcda0873626150932f438eccf0f8bf22bfa92345b814890ab360d666b254146"},
+    {file = "jupyterlab_pygments-0.2.2-py2.py3-none-any.whl", hash = "sha256:2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f"},
+    {file = "jupyterlab_pygments-0.2.2.tar.gz", hash = "sha256:7405d7fde60819d905a9fa8ce89e4cd830e318cdad22a0030f7a901da705585d"},
 ]
 kiwisolver = [
-    {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-win32.whl", hash = "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9"},
-    {file = "kiwisolver-1.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
-    {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:24cc411232d14c8abafbd0dddb83e1a4f54d77770b53db72edcfe1d611b3bf11"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ef6eefcf3944e75508cdfa513c06cf80bafd7d179e14c1334ebdca9ebb8c2c66"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
-    {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d9d8d9b31aa8c2d80a690693aebd8b5e2b7a45ab065bb78f1609995d2c79240"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:792e69140828babe9649de583e1a03a0f2ff39918a71782c76b3c683a67c6dfd"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-win32.whl", hash = "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030"},
-    {file = "kiwisolver-1.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6"},
-    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
-    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
-    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
-    {file = "kiwisolver-1.3.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d6563ccd46b645e966b400bb8a95d3457ca6cf3bba1e908f9e0927901dfebeb1"},
-    {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c79ebe8f3676a4c6630fd3f777f3cfecf9289666c84e775a67d1d358578dc2e3"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:abbe9fa13da955feb8202e215c4018f4bb57469b1b78c7a4c5c7b93001699938"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7577c1987baa3adc4b3c62c33bd1118c3ef5c8ddef36f0f2c950ae0b199e100d"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ad8285b01b0d4695102546b342b493b3ccc6781fc28c8c6a1bb63e95d22f09"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ed58b8acf29798b036d347791141767ccf65eee7f26bde03a71c944449e53de"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-win32.whl", hash = "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408"},
+    {file = "kiwisolver-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0ea21f66820452a3f5d1655f8704a60d66ba1191359b96541eaf457710a5fc6"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bc9db8a3efb3e403e4ecc6cd9489ea2bac94244f80c78e27c31dcc00d2790ac2"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d5b61785a9ce44e5a4b880272baa7cf6c8f48a5180c3e81c59553ba0cb0821ca"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2dbb44c3f7e6c4d3487b31037b1bdbf424d97687c1747ce4ff2895795c9bf69"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6295ecd49304dcf3bfbfa45d9a081c96509e95f4b9d0eb7ee4ec0530c4a96514"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bd472dbe5e136f96a4b18f295d159d7f26fd399136f5b17b08c4e5f498cd494"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf7d9fce9bcc4752ca4a1b80aabd38f6d19009ea5cbda0e0856983cf6d0023f5"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d6601aed50c74e0ef02f4204da1816147a6d3fbdc8b3872d263338a9052c51"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:877272cf6b4b7e94c9614f9b10140e198d2186363728ed0f701c6eee1baec1da"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:db608a6757adabb32f1cfe6066e39b3706d8c3aa69bbc353a5b61edad36a5cb4"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5853eb494c71e267912275e5586fe281444eb5e722de4e131cddf9d442615626"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:f0a1dbdb5ecbef0d34eb77e56fcb3e95bbd7e50835d9782a45df81cc46949750"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:283dffbf061a4ec60391d51e6155e372a1f7a4f5b15d59c8505339454f8989e4"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-win32.whl", hash = "sha256:d06adcfa62a4431d404c31216f0f8ac97397d799cd53800e9d3efc2fbb3cf14e"},
+    {file = "kiwisolver-1.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:e7da3fec7408813a7cebc9e4ec55afed2d0fd65c4754bc376bf03498d4e92686"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d0611a0a2a518464c05ddd5a3a1a0e856ccc10e67079bb17f265ad19ab3c7597"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:db5283d90da4174865d520e7366801a93777201e91e79bacbac6e6927cbceede"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1041feb4cda8708ce73bb4dcb9ce1ccf49d553bf87c3954bdfa46f0c3f77252c"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-win32.whl", hash = "sha256:a553dadda40fef6bfa1456dc4be49b113aa92c2a9a9e8711e955618cd69622e3"},
+    {file = "kiwisolver-1.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:03baab2d6b4a54ddbb43bba1a3a2d1627e82d205c5cf8f4c924dc49284b87166"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:841293b17ad704d70c578f1f0013c890e219952169ce8a24ebc063eecf775454"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f4f270de01dd3e129a72efad823da90cc4d6aafb64c410c9033aba70db9f1ff0"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f9f39e2f049db33a908319cf46624a569b36983c7c78318e9726a4cb8923b26c"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c97528e64cb9ebeff9701e7938653a9951922f2a38bd847787d4a8e498cc83ae"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d1573129aa0fd901076e2bfb4275a35f5b7aa60fbfb984499d661ec950320b0"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad881edc7ccb9d65b0224f4e4d05a1e85cf62d73aab798943df6d48ab0cd79a1"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b428ef021242344340460fa4c9185d0b1f66fbdbfecc6c63eff4b7c29fad429d"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2e407cb4bd5a13984a6c2c0fe1845e4e41e96f183e5e5cd4d77a857d9693494c"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-win32.whl", hash = "sha256:75facbe9606748f43428fc91a43edb46c7ff68889b91fa31f53b58894503a191"},
+    {file = "kiwisolver-1.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bce61af018b0cb2055e0e72e7d65290d822d3feee430b7b8203d8a855e78766"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8c808594c88a025d4e322d5bb549282c93c8e1ba71b790f539567932722d7bd8"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0a71d85ecdd570ded8ac3d1c0f480842f49a40beb423bb8014539a9f32a5897"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b533558eae785e33e8c148a8d9921692a9fe5aa516efbdff8606e7d87b9d5824"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efda5fc8cc1c61e4f639b8067d118e742b812c930f708e6667a5ce0d13499e29"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c43e1e1206cd421cd92e6b3280d4385d41d7166b3ed577ac20444b6995a445f"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc8d3bd6c72b2dd9decf16ce70e20abcb3274ba01b4e1c96031e0c4067d1e7cd"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ea39b0ccc4f5d803e3337dd46bcce60b702be4d86fd0b3d7531ef10fd99a1ac"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:968f44fdbf6dd757d12920d63b566eeb4d5b395fd2d00d29d7ef00a00582aac9"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-win32.whl", hash = "sha256:da7e547706e69e45d95e116e6939488d62174e033b763ab1496b4c29b76fabea"},
+    {file = "kiwisolver-1.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:ba59c92039ec0a66103b1d5fe588fa546373587a7d68f5c96f743c3396afc04b"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:91672bacaa030f92fc2f43b620d7b337fd9a5af28b0d6ed3f77afc43c4a64b5a"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a"},
+    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:28bc5b299f48150b5f822ce68624e445040595a4ac3d59251703779836eceff9"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:81e38381b782cc7e1e46c4e14cd997ee6040768101aefc8fa3c24a4cc58e98f8"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2a66fdfb34e05b705620dd567f5a03f239a088d5a3f321e7b6ac3239d22aa286"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:872b8ca05c40d309ed13eb2e582cab0c5a05e81e987ab9c521bf05ad1d5cf5cb"},
+    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:70e7c2e7b750585569564e2e5ca9845acfaa5da56ac46df68414f29fea97be9f"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9f85003f5dfa867e86d53fac6f7e6f30c045673fa27b603c397753bebadc3008"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e307eb9bd99801f82789b44bb45e9f541961831c7311521b13a6c85afc09767"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1792d939ec70abe76f5054d3f36ed5656021dcad1322d1cc996d4e54165cef9"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2"},
+    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b"},
+    {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
 ]
 locket = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
 MarkupSafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
-    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
 matplotlib = [
-    {file = "matplotlib-3.3.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:672960dd114e342b7c610bf32fb99d14227f29919894388b41553217457ba7ef"},
-    {file = "matplotlib-3.3.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7c155437ae4fd366e2700e2716564d1787700687443de46bcb895fe0f84b761d"},
-    {file = "matplotlib-3.3.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a17f0a10604fac7627ec82820439e7db611722e80c408a726cd00d8c974c2fb3"},
-    {file = "matplotlib-3.3.4-cp36-cp36m-win32.whl", hash = "sha256:215e2a30a2090221a9481db58b770ce56b8ef46f13224ae33afe221b14b24dc1"},
-    {file = "matplotlib-3.3.4-cp36-cp36m-win_amd64.whl", hash = "sha256:348e6032f666ffd151b323342f9278b16b95d4a75dfacae84a11d2829a7816ae"},
-    {file = "matplotlib-3.3.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:94bdd1d55c20e764d8aea9d471d2ae7a7b2c84445e0fa463f02e20f9730783e1"},
-    {file = "matplotlib-3.3.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a1acb72f095f1d58ecc2538ed1b8bca0b57df313b13db36ed34b8cdf1868e674"},
-    {file = "matplotlib-3.3.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:46b1a60a04e6d884f0250d5cc8dc7bd21a9a96c584a7acdaab44698a44710bab"},
-    {file = "matplotlib-3.3.4-cp37-cp37m-win32.whl", hash = "sha256:ed4a9e6dcacba56b17a0a9ac22ae2c72a35b7f0ef0693aa68574f0b2df607a89"},
-    {file = "matplotlib-3.3.4-cp37-cp37m-win_amd64.whl", hash = "sha256:c24c05f645aef776e8b8931cb81e0f1632d229b42b6d216e30836e2e145a2b40"},
-    {file = "matplotlib-3.3.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7310e353a4a35477c7f032409966920197d7df3e757c7624fd842f3eeb307d3d"},
-    {file = "matplotlib-3.3.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:451cc89cb33d6652c509fc6b588dc51c41d7246afdcc29b8624e256b7663ed1f"},
-    {file = "matplotlib-3.3.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3d2eb9c1cc254d0ffa90bc96fde4b6005d09c2228f99dfd493a4219c1af99644"},
-    {file = "matplotlib-3.3.4-cp38-cp38-win32.whl", hash = "sha256:e15fa23d844d54e7b3b7243afd53b7567ee71c721f592deb0727ee85e668f96a"},
-    {file = "matplotlib-3.3.4-cp38-cp38-win_amd64.whl", hash = "sha256:1de0bb6cbfe460725f0e97b88daa8643bcf9571c18ba90bb8e41432aaeca91d6"},
-    {file = "matplotlib-3.3.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f44149a0ef5b4991aaef12a93b8e8d66d6412e762745fea1faa61d98524e0ba9"},
-    {file = "matplotlib-3.3.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:746a1df55749629e26af7f977ea426817ca9370ad1569436608dc48d1069b87c"},
-    {file = "matplotlib-3.3.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:5f571b92a536206f7958f7cb2d367ff6c9a1fa8229dc35020006e4cdd1ca0acd"},
-    {file = "matplotlib-3.3.4-cp39-cp39-win32.whl", hash = "sha256:9265ae0fb35e29f9b8cc86c2ab0a2e3dcddc4dd9de4b85bf26c0f63fe5c1c2ca"},
-    {file = "matplotlib-3.3.4-cp39-cp39-win_amd64.whl", hash = "sha256:9a79e5dd7bb797aa611048f5b70588b23c5be05b63eefd8a0d152ac77c4243db"},
-    {file = "matplotlib-3.3.4-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1e850163579a8936eede29fad41e202b25923a0a8d5ffd08ce50fc0a97dcdc93"},
-    {file = "matplotlib-3.3.4-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:d738acfdfb65da34c91acbdb56abed46803db39af259b7f194dc96920360dbe4"},
-    {file = "matplotlib-3.3.4-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:aa49571d8030ad0b9ac39708ee77bd2a22f87815e12bdee52ecaffece9313ed8"},
-    {file = "matplotlib-3.3.4-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:cf3a7e54eff792f0815dbbe9b85df2f13d739289c93d346925554f71d484be78"},
-    {file = "matplotlib-3.3.4.tar.gz", hash = "sha256:3e477db76c22929e4c6876c44f88d790aacdf3c3f8f3a90cb1975c0bf37825b0"},
+    {file = "matplotlib-3.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a206a1b762b39398efea838f528b3a6d60cdb26fe9d58b48265787e29cd1d693"},
+    {file = "matplotlib-3.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd45a6f3e93a780185f70f05cf2a383daed13c3489233faad83e81720f7ede24"},
+    {file = "matplotlib-3.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d62880e1f60e5a30a2a8484432bcb3a5056969dc97258d7326ad465feb7ae069"},
+    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ab29589cef03bc88acfa3a1490359000c18186fc30374d8aa77d33cc4a51a4a"},
+    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2886cc009f40e2984c083687251821f305d811d38e3df8ded414265e4583f0c5"},
+    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c995f7d9568f18b5db131ab124c64e51b6820a92d10246d4f2b3f3a66698a15b"},
+    {file = "matplotlib-3.5.3-cp310-cp310-win32.whl", hash = "sha256:6bb93a0492d68461bd458eba878f52fdc8ac7bdb6c4acdfe43dba684787838c2"},
+    {file = "matplotlib-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:2e6d184ebe291b9e8f7e78bbab7987d269c38ea3e062eace1fe7d898042ef804"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ea6aef5c4338e58d8d376068e28f80a24f54e69f09479d1c90b7172bad9f25b"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:839d47b8ead7ad9669aaacdbc03f29656dc21f0d41a6fea2d473d856c39c8b1c"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3b4fa56159dc3c7f9250df88f653f085068bcd32dcd38e479bba58909254af7f"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:94ff86af56a3869a4ae26a9637a849effd7643858a1a04dd5ee50e9ab75069a7"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-win32.whl", hash = "sha256:35a8ad4dddebd51f94c5d24bec689ec0ec66173bf614374a1244c6241c1595e0"},
+    {file = "matplotlib-3.5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:43e9d3fa077bf0cc95ded13d331d2156f9973dce17c6f0c8b49ccd57af94dbd9"},
+    {file = "matplotlib-3.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:22227c976ad4dc8c5a5057540421f0d8708c6560744ad2ad638d48e2984e1dbc"},
+    {file = "matplotlib-3.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf618a825deb6205f015df6dfe6167a5d9b351203b03fab82043ae1d30f16511"},
+    {file = "matplotlib-3.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9befa5954cdbc085e37d974ff6053da269474177921dd61facdad8023c4aeb51"},
+    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3840c280ebc87a48488a46f760ea1c0c0c83fcf7abbe2e6baf99d033fd35fd8"},
+    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dacddf5bfcec60e3f26ec5c0ae3d0274853a258b6c3fc5ef2f06a8eb23e042be"},
+    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b428076a55fb1c084c76cb93e68006f27d247169f056412607c5c88828d08f88"},
+    {file = "matplotlib-3.5.3-cp38-cp38-win32.whl", hash = "sha256:874df7505ba820e0400e7091199decf3ff1fde0583652120c50cd60d5820ca9a"},
+    {file = "matplotlib-3.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:b28de401d928890187c589036857a270a032961411934bdac4cf12dde3d43094"},
+    {file = "matplotlib-3.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3211ba82b9f1518d346f6309df137b50c3dc4421b4ed4815d1d7eadc617f45a1"},
+    {file = "matplotlib-3.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6fe807e8a22620b4cd95cfbc795ba310dc80151d43b037257250faf0bfcd82bc"},
+    {file = "matplotlib-3.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5c096363b206a3caf43773abebdbb5a23ea13faef71d701b21a9c27fdcef72f4"},
+    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bcdfcb0f976e1bac6721d7d457c17be23cf7501f977b6a38f9d38a3762841f7"},
+    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e64ac9be9da6bfff0a732e62116484b93b02a0b4d4b19934fb4f8e7ad26ad6a"},
+    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:73dd93dc35c85dece610cca8358003bf0760d7986f70b223e2306b4ea6d1406b"},
+    {file = "matplotlib-3.5.3-cp39-cp39-win32.whl", hash = "sha256:879c7e5fce4939c6aa04581dfe08d57eb6102a71f2e202e3314d5fbc072fd5a0"},
+    {file = "matplotlib-3.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:ab8d26f07fe64f6f6736d635cce7bfd7f625320490ed5bfc347f2cdb4fae0e56"},
+    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:99482b83ebf4eb6d5fc6813d7aacdefdd480f0d9c0b52dcf9f1cc3b2c4b3361a"},
+    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f814504e459c68118bf2246a530ed953ebd18213dc20e3da524174d84ed010b2"},
+    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57f1b4e69f438a99bb64d7f2c340db1b096b41ebaa515cf61ea72624279220ce"},
+    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d2484b350bf3d32cae43f85dcfc89b3ed7bd2bcd781ef351f93eb6fb2cc483f9"},
+    {file = "matplotlib-3.5.3.tar.gz", hash = "sha256:339cac48b80ddbc8bfd05daae0a3a73414651a8596904c2a881cfd1edb65f26c"},
+]
+matplotlib-inline = [
+    {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
+    {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
 ]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
@@ -1832,60 +1962,50 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nbclient = [
-    {file = "nbclient-0.5.9-py3-none-any.whl", hash = "sha256:8a307be4129cce5f70eb83a57c3edbe45656623c31de54e38bb6fdfbadc428b3"},
-    {file = "nbclient-0.5.9.tar.gz", hash = "sha256:99e46ddafacd0b861293bf246fed8540a184adfa3aa7d641f89031ec070701e0"},
+    {file = "nbclient-0.5.13-py3-none-any.whl", hash = "sha256:47ac905af59379913c1f8f541098d2550153cf8dc58553cbe18c702b181518b0"},
+    {file = "nbclient-0.5.13.tar.gz", hash = "sha256:40c52c9b5e3c31faecaee69f202b3f53e38d7c1c563de0fadde9d7eda0fdafe8"},
 ]
 nbconvert = [
-    {file = "nbconvert-6.0.7-py3-none-any.whl", hash = "sha256:39e9f977920b203baea0be67eea59f7b37a761caa542abe80f5897ce3cf6311d"},
-    {file = "nbconvert-6.0.7.tar.gz", hash = "sha256:cbbc13a86dfbd4d1b5dee106539de0795b4db156c894c2c5dc382062bbc29002"},
+    {file = "nbconvert-6.4.5-py3-none-any.whl", hash = "sha256:e01d219f55cc79f9701c834d605e8aa3acf35725345d3942e3983937f368ce14"},
+    {file = "nbconvert-6.4.5.tar.gz", hash = "sha256:21163a8e2073c07109ca8f398836e45efdba2aacea68d6f75a8a545fef070d4e"},
 ]
 nbformat = [
-    {file = "nbformat-5.1.3-py3-none-any.whl", hash = "sha256:eb8447edd7127d043361bc17f2f5a807626bc8e878c7709a1c647abda28a9171"},
-    {file = "nbformat-5.1.3.tar.gz", hash = "sha256:b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8"},
+    {file = "nbformat-5.5.0-py3-none-any.whl", hash = "sha256:eb21018bbcdb29e7a4b8b29068d4b6794cdad685db8fcd569b97a09a048dc2e4"},
+    {file = "nbformat-5.5.0.tar.gz", hash = "sha256:9ebe30e6c3b3e5b47d39ff0a3897a1acf523d2bfafcb4e2d04cdb70f8a66c507"},
 ]
 nest-asyncio = [
     {file = "nest_asyncio-1.5.5-py3-none-any.whl", hash = "sha256:b98e3ec1b246135e4642eceffa5a6c23a3ab12c82ff816a92c612d68205813b2"},
     {file = "nest_asyncio-1.5.5.tar.gz", hash = "sha256:e442291cd942698be619823a17a86a5759eabe1f8613084790de189fe9e16d65"},
 ]
 networkx = [
-    {file = "networkx-2.5.1-py3-none-any.whl", hash = "sha256:0635858ed7e989f4c574c2328380b452df892ae85084144c73d8cd819f0c4e06"},
-    {file = "networkx-2.5.1.tar.gz", hash = "sha256:109cd585cac41297f71103c3c42ac6ef7379f29788eb54cb751be5a663bb235a"},
+    {file = "networkx-2.6.3-py3-none-any.whl", hash = "sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef"},
+    {file = "networkx-2.6.3.tar.gz", hash = "sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51"},
 ]
 numpy = [
-    {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76"},
-    {file = "numpy-1.19.5-cp36-cp36m-win32.whl", hash = "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a"},
-    {file = "numpy-1.19.5-cp36-cp36m-win_amd64.whl", hash = "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827"},
-    {file = "numpy-1.19.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28"},
-    {file = "numpy-1.19.5-cp37-cp37m-win32.whl", hash = "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7"},
-    {file = "numpy-1.19.5-cp37-cp37m-win_amd64.whl", hash = "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d"},
-    {file = "numpy-1.19.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc"},
-    {file = "numpy-1.19.5-cp38-cp38-win32.whl", hash = "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2"},
-    {file = "numpy-1.19.5-cp38-cp38-win_amd64.whl", hash = "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa"},
-    {file = "numpy-1.19.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"},
-    {file = "numpy-1.19.5-cp39-cp39-win32.whl", hash = "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e"},
-    {file = "numpy-1.19.5-cp39-cp39-win_amd64.whl", hash = "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e"},
-    {file = "numpy-1.19.5-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73"},
-    {file = "numpy-1.19.5.zip", hash = "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4"},
+    {file = "numpy-1.20.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e9459f40244bb02b2f14f6af0cd0732791d72232bbb0dc4bab57ef88e75f6935"},
+    {file = "numpy-1.20.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a8e6859913ec8eeef3dbe9aed3bf475347642d1cdd6217c30f28dee8903528e6"},
+    {file = "numpy-1.20.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:9cab23439eb1ebfed1aaec9cd42b7dc50fc96d5cd3147da348d9161f0501ada5"},
+    {file = "numpy-1.20.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:9c0fab855ae790ca74b27e55240fe4f2a36a364a3f1ebcfd1fb5ac4088f1cec3"},
+    {file = "numpy-1.20.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:61d5b4cf73622e4d0c6b83408a16631b670fc045afd6540679aa35591a17fe6d"},
+    {file = "numpy-1.20.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d15007f857d6995db15195217afdbddfcd203dfaa0ba6878a2f580eaf810ecd6"},
+    {file = "numpy-1.20.2-cp37-cp37m-win32.whl", hash = "sha256:d76061ae5cab49b83a8cf3feacefc2053fac672728802ac137dd8c4123397677"},
+    {file = "numpy-1.20.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bad70051de2c50b1a6259a6df1daaafe8c480ca98132da98976d8591c412e737"},
+    {file = "numpy-1.20.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:719656636c48be22c23641859ff2419b27b6bdf844b36a2447cb39caceb00935"},
+    {file = "numpy-1.20.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:aa046527c04688af680217fffac61eec2350ef3f3d7320c07fd33f5c6e7b4d5f"},
+    {file = "numpy-1.20.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2428b109306075d89d21135bdd6b785f132a1f5a3260c371cee1fae427e12727"},
+    {file = "numpy-1.20.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:e8e4fbbb7e7634f263c5b0150a629342cc19b47c5eba8d1cd4363ab3455ab576"},
+    {file = "numpy-1.20.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:edb1f041a9146dcf02cd7df7187db46ab524b9af2515f392f337c7cbbf5b52cd"},
+    {file = "numpy-1.20.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:c73a7975d77f15f7f68dacfb2bca3d3f479f158313642e8ea9058eea06637931"},
+    {file = "numpy-1.20.2-cp38-cp38-win32.whl", hash = "sha256:6c915ee7dba1071554e70a3664a839fbc033e1d6528199d4621eeaaa5487ccd2"},
+    {file = "numpy-1.20.2-cp38-cp38-win_amd64.whl", hash = "sha256:471c0571d0895c68da309dacee4e95a0811d0a9f9f532a48dc1bea5f3b7ad2b7"},
+    {file = "numpy-1.20.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4703b9e937df83f5b6b7447ca5912b5f5f297aba45f91dbbbc63ff9278c7aa98"},
+    {file = "numpy-1.20.2-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:abc81829c4039e7e4c30f7897938fa5d4916a09c2c7eb9b244b7a35ddc9656f4"},
+    {file = "numpy-1.20.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:377751954da04d4a6950191b20539066b4e19e3b559d4695399c5e8e3e683bf6"},
+    {file = "numpy-1.20.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6e51e417d9ae2e7848314994e6fc3832c9d426abce9328cf7571eefceb43e6c9"},
+    {file = "numpy-1.20.2-cp39-cp39-win32.whl", hash = "sha256:780ae5284cb770ade51d4b4a7dce4faa554eb1d88a56d0e8b9f35fca9b0270ff"},
+    {file = "numpy-1.20.2-cp39-cp39-win_amd64.whl", hash = "sha256:924dc3f83de20437de95a73516f36e09918e9c9c18d5eac520062c49191025fb"},
+    {file = "numpy-1.20.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:97ce8b8ace7d3b9288d88177e66ee75480fb79b9cf745e91ecfe65d91a856042"},
+    {file = "numpy-1.20.2.zip", hash = "sha256:878922bf5ad7550aa044aa9301d417e2d3ae50f0f577de92051d739ac6096cee"},
 ]
 otumat = [
     {file = "otumat-0.3.1-py3-none-any.whl", hash = "sha256:5388682703da1c5bf809af505639b7d374522d91cf71dd1f185d5a334040d208"},
@@ -1896,38 +2016,46 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.0.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"},
-    {file = "pandas-1.0.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9c31d52f1a7dd2bb4681d9f62646c7aa554f19e8e9addc17e8b1b20011d7522d"},
-    {file = "pandas-1.0.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8778a5cc5a8437a561e3276b85367412e10ae9fff07db1eed986e427d9a674f8"},
-    {file = "pandas-1.0.5-cp36-cp36m-win32.whl", hash = "sha256:9871ef5ee17f388f1cb35f76dc6106d40cb8165c562d573470672f4cdefa59ef"},
-    {file = "pandas-1.0.5-cp36-cp36m-win_amd64.whl", hash = "sha256:35b670b0abcfed7cad76f2834041dcf7ae47fd9b22b63622d67cdc933d79f453"},
-    {file = "pandas-1.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c9410ce8a3dee77653bc0684cfa1535a7f9c291663bd7ad79e39f5ab58f67ab3"},
-    {file = "pandas-1.0.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096"},
-    {file = "pandas-1.0.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b3c4f93fcb6e97d993bf87cdd917883b7dab7d20c627699f360a8fb49e9e0b91"},
-    {file = "pandas-1.0.5-cp37-cp37m-win32.whl", hash = "sha256:5759edf0b686b6f25a5d4a447ea588983a33afc8a0081a0954184a4a87fd0dd7"},
-    {file = "pandas-1.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:ab8173a8efe5418bbe50e43f321994ac6673afc5c7c4839014cf6401bbdd0705"},
-    {file = "pandas-1.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:13f75fb18486759da3ff40f5345d9dd20e7d78f2a39c5884d013456cec9876f0"},
-    {file = "pandas-1.0.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5a7cf6044467c1356b2b49ef69e50bf4d231e773c3ca0558807cdba56b76820b"},
-    {file = "pandas-1.0.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ae961f1f0e270f1e4e2273f6a539b2ea33248e0e3a11ffb479d757918a5e03a9"},
-    {file = "pandas-1.0.5-cp38-cp38-win32.whl", hash = "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107"},
-    {file = "pandas-1.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c73f373b0800eb3062ffd13d4a7a2a6d522792fa6eb204d67a4fad0a40f03dc"},
-    {file = "pandas-1.0.5.tar.gz", hash = "sha256:69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8"},
+    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
+    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
+    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
+    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
+    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
+    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
+    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
+    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
+    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
+    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
+    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
+    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
+    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
     {file = "pandocfilters-1.5.0.tar.gz", hash = "sha256:0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38"},
 ]
 parso = [
-    {file = "parso-0.7.1-py2.py3-none-any.whl", hash = "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea"},
-    {file = "parso-0.7.1.tar.gz", hash = "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"},
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
 partd = [
-    {file = "partd-1.2.0-py3-none-any.whl", hash = "sha256:5c3a5d70da89485c27916328dc1e26232d0e270771bd4caef4a5124b6a457288"},
-    {file = "partd-1.2.0.tar.gz", hash = "sha256:aa67897b84d522dcbc86a98b942afab8c6aa2f7f677d904a616b74ef5ddbc3eb"},
+    {file = "partd-1.3.0-py3-none-any.whl", hash = "sha256:6393a0c898a0ad945728e34e52de0df3ae295c5aff2e2926ba7cc3c60a734a15"},
+    {file = "partd-1.3.0.tar.gz", hash = "sha256:ce91abcdc6178d668bcaa431791a5a917d902341cb193f543fe445d494660485"},
 ]
 pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
@@ -1938,51 +2066,72 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 Pillow = [
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d82cdb63100ef5eedb8391732375e6d05993b765f72cb34311fab92103314649"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc1afda735a8d109007164714e73771b499768b9bb5afcbbee9d0ff374b43f"},
-    {file = "Pillow-8.4.0-cp310-cp310-win32.whl", hash = "sha256:e3dacecfbeec9a33e932f00c6cd7996e62f53ad46fbe677577394aaa90ee419a"},
-    {file = "Pillow-8.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:620582db2a85b2df5f8a82ddeb52116560d7e5e6b055095f04ad828d1b0baa39"},
-    {file = "Pillow-8.4.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:1bc723b434fbc4ab50bb68e11e93ce5fb69866ad621e3c2c9bdb0cd70e345f55"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cbcfd54df6caf85cc35264c77ede902452d6df41166010262374155947460c"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70ad9e5c6cb9b8487280a02c0ad8a51581dcbbe8484ce058477692a27c151c0a"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25a49dc2e2f74e65efaa32b153527fc5ac98508d502fa46e74fa4fd678ed6645"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win32.whl", hash = "sha256:93ce9e955cc95959df98505e4608ad98281fff037350d8c2671c9aa86bcf10a9"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2e4440b8f00f504ee4b53fe30f4e381aae30b0568193be305256b1462216feff"},
-    {file = "Pillow-8.4.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8c803ac3c28bbc53763e6825746f05cc407b20e4a69d0122e526a582e3b5e153"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8a17b5d948f4ceeceb66384727dde11b240736fddeda54ca740b9b8b1556b29"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1394a6ad5abc838c5cd8a92c5a07535648cdf6d09e8e2d6df916dfa9ea86ead8"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792e5c12376594bfcb986ebf3855aa4b7c225754e9a9521298e460e92fb4a488"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win32.whl", hash = "sha256:d99ec152570e4196772e7a8e4ba5320d2d27bf22fdf11743dd882936ed64305b"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7b7017b61bbcdd7f6363aeceb881e23c46583739cb69a3ab39cb384f6ec82e5b"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d89363f02658e253dbd171f7c3716a5d340a24ee82d38aab9183f7fdf0cdca49"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a0956fdc5defc34462bb1c765ee88d933239f9a94bc37d132004775241a7585"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b7bb9de00197fb4261825c15551adf7605cf14a80badf1761d61e59da347779"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72b9e656e340447f827885b8d7a15fc8c4e68d410dc2297ef6787eec0f0ea409"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5a4532a12314149d8b4e4ad8ff09dde7427731fcfa5917ff16d0291f13609df"},
-    {file = "Pillow-8.4.0-cp38-cp38-win32.whl", hash = "sha256:82aafa8d5eb68c8463b6e9baeb4f19043bb31fefc03eb7b216b51e6a9981ae09"},
-    {file = "Pillow-8.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:066f3999cb3b070a95c3652712cffa1a748cd02d60ad7b4e485c3748a04d9d76"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:493cb4e415f44cd601fcec11c99836f707bb714ab03f5ed46ac25713baf0ff20"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed"},
-    {file = "Pillow-8.4.0-cp39-cp39-win32.whl", hash = "sha256:5e9ac5f66616b87d4da618a20ab0a38324dbe88d8a39b55be8964eb520021e02"},
-    {file = "Pillow-8.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ddc4d832a0f0b4c52fff973a0d44b6c99839a9d016fe4e6a1cb8f3eea96479c2"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a3e5ddc44c14042f0844b8cf7d2cd455f6cc80fd7f5eefbe657292cf601d9ad"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70e94281588ef053ae8998039610dbd71bc509e4acbc77ab59d7d2937b10698"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:3862b7256046fcd950618ed22d1d60b842e3a40a48236a5498746f21189afbbc"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4901622493f88b1a29bd30ec1a2f683782e57c3c16a2dbc7f2595ba01f639df"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84c471a734240653a0ec91dec0996696eea227eafe72a33bd06c92697728046b"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:244cf3b97802c34c41905d22810846802a3329ddcb93ccc432870243211c79fc"},
-    {file = "Pillow-8.4.0.tar.gz", hash = "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed"},
+    {file = "Pillow-9.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb"},
+    {file = "Pillow-9.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f"},
+    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7888310f6214f19ab2b6df90f3f06afa3df7ef7355fc025e78a3044737fab1f5"},
+    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:831e648102c82f152e14c1a0938689dbb22480c548c8d4b8b248b3e50967b88c"},
+    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cc1d2451e8a3b4bfdb9caf745b58e6c7a77d2e469159b0d527a4554d73694d1"},
+    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:136659638f61a251e8ed3b331fc6ccd124590eeff539de57c5f80ef3a9594e58"},
+    {file = "Pillow-9.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6e8c66f70fb539301e064f6478d7453e820d8a2c631da948a23384865cd95544"},
+    {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
+    {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
+    {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
+    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
+    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
+    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},
+    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:15928f824870535c85dbf949c09d6ae7d3d6ac2d6efec80f3227f73eefba741c"},
+    {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:bdd0de2d64688ecae88dd8935012c4a72681e5df632af903a1dca8c5e7aa871a"},
+    {file = "Pillow-9.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5b87da55a08acb586bad5c3aa3b86505f559b84f39035b233d5bf844b0834b1"},
+    {file = "Pillow-9.2.0-cp311-cp311-win32.whl", hash = "sha256:b6d5e92df2b77665e07ddb2e4dbd6d644b78e4c0d2e9272a852627cdba0d75cf"},
+    {file = "Pillow-9.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6bf088c1ce160f50ea40764f825ec9b72ed9da25346216b91361eef8ad1b8f8c"},
+    {file = "Pillow-9.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:2c58b24e3a63efd22554c676d81b0e57f80e0a7d3a5874a7e14ce90ec40d3069"},
+    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef7592281f7c174d3d6cbfbb7ee5984a671fcd77e3fc78e973d492e9bf0eb3f"},
+    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcd7b9c7139dc8258d164b55696ecd16c04607f1cc33ba7af86613881ffe4ac8"},
+    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a138441e95562b3c078746a22f8fca8ff1c22c014f856278bdbdd89ca36cff1b"},
+    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:93689632949aff41199090eff5474f3990b6823404e45d66a5d44304e9cdc467"},
+    {file = "Pillow-9.2.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:f3fac744f9b540148fa7715a435d2283b71f68bfb6d4aae24482a890aed18b59"},
+    {file = "Pillow-9.2.0-cp37-cp37m-win32.whl", hash = "sha256:fa768eff5f9f958270b081bb33581b4b569faabf8774726b283edb06617101dc"},
+    {file = "Pillow-9.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:69bd1a15d7ba3694631e00df8de65a8cb031911ca11f44929c97fe05eb9b6c1d"},
+    {file = "Pillow-9.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:030e3460861488e249731c3e7ab59b07c7853838ff3b8e16aac9561bb345da14"},
+    {file = "Pillow-9.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:74a04183e6e64930b667d321524e3c5361094bb4af9083db5c301db64cd341f3"},
+    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d33a11f601213dcd5718109c09a52c2a1c893e7461f0be2d6febc2879ec2402"},
+    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd6f5e3c0e4697fa7eb45b6e93996299f3feee73a3175fa451f49a74d092b9f"},
+    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a647c0d4478b995c5e54615a2e5360ccedd2f85e70ab57fbe817ca613d5e63b8"},
+    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:4134d3f1ba5f15027ff5c04296f13328fecd46921424084516bdb1b2548e66ff"},
+    {file = "Pillow-9.2.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:bc431b065722a5ad1dfb4df354fb9333b7a582a5ee39a90e6ffff688d72f27a1"},
+    {file = "Pillow-9.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1536ad017a9f789430fb6b8be8bf99d2f214c76502becc196c6f2d9a75b01b76"},
+    {file = "Pillow-9.2.0-cp38-cp38-win32.whl", hash = "sha256:2ad0d4df0f5ef2247e27fc790d5c9b5a0af8ade9ba340db4a73bb1a4a3e5fb4f"},
+    {file = "Pillow-9.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:ec52c351b35ca269cb1f8069d610fc45c5bd38c3e91f9ab4cbbf0aebc136d9c8"},
+    {file = "Pillow-9.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ed2c4ef2451de908c90436d6e8092e13a43992f1860275b4d8082667fbb2ffc"},
+    {file = "Pillow-9.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da"},
+    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea98f633d45f7e815db648fd7ff0f19e328302ac36427343e4432c84432e7ff4"},
+    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7761afe0126d046974a01e030ae7529ed0ca6a196de3ec6937c11df0df1bc91c"},
+    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a54614049a18a2d6fe156e68e188da02a046a4a93cf24f373bffd977e943421"},
+    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:5aed7dde98403cd91d86a1115c78d8145c83078e864c1de1064f52e6feb61b20"},
+    {file = "Pillow-9.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:13b725463f32df1bfeacbf3dd197fb358ae8ebcd8c5548faa75126ea425ccb60"},
+    {file = "Pillow-9.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:808add66ea764ed97d44dda1ac4f2cfec4c1867d9efb16a33d158be79f32b8a4"},
+    {file = "Pillow-9.2.0-cp39-cp39-win32.whl", hash = "sha256:337a74fd2f291c607d220c793a8135273c4c2ab001b03e601c36766005f36885"},
+    {file = "Pillow-9.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:fac2d65901fb0fdf20363fbd345c01958a742f2dc62a8dd4495af66e3ff502a4"},
+    {file = "Pillow-9.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ad2277b185ebce47a63f4dc6302e30f05762b688f8dc3de55dbae4651872cdf3"},
+    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c7b502bc34f6e32ba022b4a209638f9e097d7a9098104ae420eb8186217ebbb"},
+    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d1f14f5f691f55e1b47f824ca4fdcb4b19b4323fe43cc7bb105988cad7496be"},
+    {file = "Pillow-9.2.0-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:dfe4c1fedfde4e2fbc009d5ad420647f7730d719786388b7de0999bf32c0d9fd"},
+    {file = "Pillow-9.2.0-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:f07f1f00e22b231dd3d9b9208692042e29792d6bd4f6639415d2f23158a80013"},
+    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1802f34298f5ba11d55e5bb09c31997dc0c6aed919658dfdf0198a2fe75d5490"},
+    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17d4cafe22f050b46d983b71c707162d63d796a1235cdf8b9d7a112e97b15bac"},
+    {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96b5e6874431df16aee0c1ba237574cb6dff1dcb173798faa6a9d8b399a05d0e"},
+    {file = "Pillow-9.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927"},
+    {file = "Pillow-9.2.0.tar.gz", hash = "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"},
+]
+pkgutil_resolve_name = [
+    {file = "pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"},
+    {file = "pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
 plotly = [
     {file = "plotly-5.10.0-py2.py3-none-any.whl", hash = "sha256:989b13825cc974390aa0169479485d9257d37848a47bc63957251f8e1a7046ba"},
@@ -1991,6 +2140,40 @@ plotly = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.31-py3-none-any.whl", hash = "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d"},
     {file = "prompt_toolkit-3.0.31.tar.gz", hash = "sha256:9ada952c9d1787f52ff6d5f3484d0b4df8952787c087edf6a1f7c2cb1ea88148"},
+]
+psutil = [
+    {file = "psutil-5.9.2-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:8f024fbb26c8daf5d70287bb3edfafa22283c255287cf523c5d81721e8e5d82c"},
+    {file = "psutil-5.9.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:b2f248ffc346f4f4f0d747ee1947963613216b06688be0be2e393986fe20dbbb"},
+    {file = "psutil-5.9.2-cp27-cp27m-win32.whl", hash = "sha256:b1928b9bf478d31fdffdb57101d18f9b70ed4e9b0e41af751851813547b2a9ab"},
+    {file = "psutil-5.9.2-cp27-cp27m-win_amd64.whl", hash = "sha256:404f4816c16a2fcc4eaa36d7eb49a66df2d083e829d3e39ee8759a411dbc9ecf"},
+    {file = "psutil-5.9.2-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:94e621c6a4ddb2573d4d30cba074f6d1aa0186645917df42c811c473dd22b339"},
+    {file = "psutil-5.9.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:256098b4f6ffea6441eb54ab3eb64db9ecef18f6a80d7ba91549195d55420f84"},
+    {file = "psutil-5.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:614337922702e9be37a39954d67fdb9e855981624d8011a9927b8f2d3c9625d9"},
+    {file = "psutil-5.9.2-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39ec06dc6c934fb53df10c1672e299145ce609ff0611b569e75a88f313634969"},
+    {file = "psutil-5.9.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3ac2c0375ef498e74b9b4ec56df3c88be43fe56cac465627572dbfb21c4be34"},
+    {file = "psutil-5.9.2-cp310-cp310-win32.whl", hash = "sha256:e4c4a7636ffc47b7141864f1c5e7d649f42c54e49da2dd3cceb1c5f5d29bfc85"},
+    {file = "psutil-5.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:f4cb67215c10d4657e320037109939b1c1d2fd70ca3d76301992f89fe2edb1f1"},
+    {file = "psutil-5.9.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dc9bda7d5ced744622f157cc8d8bdd51735dafcecff807e928ff26bdb0ff097d"},
+    {file = "psutil-5.9.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75291912b945a7351d45df682f9644540d564d62115d4a20d45fa17dc2d48f8"},
+    {file = "psutil-5.9.2-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4018d5f9b6651f9896c7a7c2c9f4652e4eea53f10751c4e7d08a9093ab587ec"},
+    {file = "psutil-5.9.2-cp36-cp36m-win32.whl", hash = "sha256:f40ba362fefc11d6bea4403f070078d60053ed422255bd838cd86a40674364c9"},
+    {file = "psutil-5.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:9770c1d25aee91417eba7869139d629d6328a9422ce1cdd112bd56377ca98444"},
+    {file = "psutil-5.9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:42638876b7f5ef43cef8dcf640d3401b27a51ee3fa137cb2aa2e72e188414c32"},
+    {file = "psutil-5.9.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91aa0dac0c64688667b4285fa29354acfb3e834e1fd98b535b9986c883c2ce1d"},
+    {file = "psutil-5.9.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb54941aac044a61db9d8eb56fc5bee207db3bc58645d657249030e15ba3727"},
+    {file = "psutil-5.9.2-cp37-cp37m-win32.whl", hash = "sha256:7cbb795dcd8ed8fd238bc9e9f64ab188f3f4096d2e811b5a82da53d164b84c3f"},
+    {file = "psutil-5.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:5d39e3a2d5c40efa977c9a8dd4f679763c43c6c255b1340a56489955dbca767c"},
+    {file = "psutil-5.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd331866628d18223a4265371fd255774affd86244fc307ef66eaf00de0633d5"},
+    {file = "psutil-5.9.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b315febaebae813326296872fdb4be92ad3ce10d1d742a6b0c49fb619481ed0b"},
+    {file = "psutil-5.9.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7929a516125f62399d6e8e026129c8835f6c5a3aab88c3fff1a05ee8feb840d"},
+    {file = "psutil-5.9.2-cp38-cp38-win32.whl", hash = "sha256:561dec454853846d1dd0247b44c2e66a0a0c490f937086930ec4b8f83bf44f06"},
+    {file = "psutil-5.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:67b33f27fc0427483b61563a16c90d9f3b547eeb7af0ef1b9fe024cdc9b3a6ea"},
+    {file = "psutil-5.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3591616fa07b15050b2f87e1cdefd06a554382e72866fcc0ab2be9d116486c8"},
+    {file = "psutil-5.9.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14b29f581b5edab1f133563272a6011925401804d52d603c5c606936b49c8b97"},
+    {file = "psutil-5.9.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4642fd93785a29353d6917a23e2ac6177308ef5e8be5cc17008d885cb9f70f12"},
+    {file = "psutil-5.9.2-cp39-cp39-win32.whl", hash = "sha256:ed29ea0b9a372c5188cdb2ad39f937900a10fb5478dc077283bf86eeac678ef1"},
+    {file = "psutil-5.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:68b35cbff92d1f7103d8f1db77c977e72f49fcefae3d3d2b91c76b0e7aef48b8"},
+    {file = "psutil-5.9.2.tar.gz", hash = "sha256:feb861a10b6c3bb00701063b37e4afc754f8217f0f09c42280586bd6ac712b5c"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -2028,31 +2211,31 @@ PyMySQL = [
     {file = "PyMySQL-1.0.2.tar.gz", hash = "sha256:816927a350f38d56072aeca5dfb10221fe1dc653745853d30a216637f5d7ad36"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
-    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win32.whl", hash = "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win32.whl", hash = "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win_amd64.whl", hash = "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win32.whl", hash = "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win_amd64.whl", hash = "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win32.whl", hash = "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea"},
-    {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -2086,6 +2269,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -2114,80 +2304,53 @@ PyYAML = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 pyzmq = [
-    {file = "pyzmq-23.2.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:a3fd44b5046d247e7f0f1660bcafe7b5fb0db55d0934c05dd57dda9e1f823ce7"},
-    {file = "pyzmq-23.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2141e6798d5981be04c08996d27962086a1aa3ea536fe9cf7e89817fd4523f86"},
-    {file = "pyzmq-23.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a39ddb0431a68954bd318b923230fa5b649c9c62b0e8340388820c5f1b15bd2"},
-    {file = "pyzmq-23.2.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e06747014a5ad1b28cebf5bc1ddcdaccfb44e9b441d35e6feb1286c8a72e54be"},
-    {file = "pyzmq-23.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e0113d70b095339e99bb522fe7294f5ae6a7f3b2b8f52f659469a74b5cc7661"},
-    {file = "pyzmq-23.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:71b32a1e827bdcbf73750e60370d3b07685816ff3d8695f450f0f8c3226503f8"},
-    {file = "pyzmq-23.2.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:55568a020ad2cae9ae36da6058e7ca332a56df968f601cbdb7cf6efb2a77579a"},
-    {file = "pyzmq-23.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8c02a0cd39dc01659b3d6cb70bb3a41aebd9885fd78239acdd8d9c91351c4568"},
-    {file = "pyzmq-23.2.1-cp310-cp310-win32.whl", hash = "sha256:e1fe30bcd5aea5948c42685fad910cd285eacb2518ea4dc6c170d6b535bee95d"},
-    {file = "pyzmq-23.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:650389bbfca73955b262b2230423d89992f38ec48033307ae80e700eaa2fbb63"},
-    {file = "pyzmq-23.2.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:e753eee6d3b93c5354e8ba0a1d62956ee49355f0a36e00570823ef64e66183f5"},
-    {file = "pyzmq-23.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f07016e3cf088dbfc6e7c5a7b3f540db5c23b0190d539e4fd3e2b5e6beffa4b5"},
-    {file = "pyzmq-23.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4805af9614b0b41b7e57d17673459facf85604dac502a5a9244f6e8c9a4de658"},
-    {file = "pyzmq-23.2.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39dd252b683816935702825e5bf775df16090619ced9bb4ba68c2d0b6f0c9b18"},
-    {file = "pyzmq-23.2.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:84678153432241bcdca2210cf4ff83560b200556867aea913ffbb960f5d5f340"},
-    {file = "pyzmq-23.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:90d88f9d9a2ae6cfb1dc4ea2d1710cdf6456bc1b9a06dd1bb485c5d298f2517e"},
-    {file = "pyzmq-23.2.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:794871988c34727c7f79bdfe2546e6854ae1fa2e1feb382784f23a9c6c63ecb3"},
-    {file = "pyzmq-23.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c56b1a62a1fb87565343c57b6743fd5da6e138b8c6562361d7d9b5ce4acf399a"},
-    {file = "pyzmq-23.2.1-cp311-cp311-win32.whl", hash = "sha256:c3ebf1668664d20c8f7d468955f18379b7d1f7bc8946b13243d050fa3888c7ff"},
-    {file = "pyzmq-23.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:ec9803aca9491fd6f0d853d2a6147f19f8deaaa23b1b713d05c5d09e56ea7142"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:385609812eafd9970c3752c51f2f6c4f224807e3e441bcfd8c8273877d00c8a8"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b861db65f6b8906c8d6db51dde2448f266f0c66bf28db2c37aea50f58a849859"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6b1e79bba24f6df1712e3188d5c32c480d8eda03e8ecff44dc8ecb0805fa62f3"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8dc66f109a245653b19df0f44a5af7a3f14cb8ad6c780ead506158a057bd36ce"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:b815991c7d024bf461f358ad871f2be1135576274caed5749c4828859e40354e"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:29b74774a0bfd3c4d98ac853f0bdca55bd9ec89d5b0def5486407cca54472ef8"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:4bb798bef181648827019001f6be43e1c48b34b477763b37a8d27d8c06d197b8"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-win32.whl", hash = "sha256:565bd5ab81f6964fc4067ccf2e00877ad0fa917308975694bbb54378389215f8"},
-    {file = "pyzmq-23.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:1f368a82b29f80071781b20663c0fc0c8f6b13273f9f5abe1526af939534f90f"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c9cfaf530e6a7ff65f0afe275e99f983f68b54dfb23ea401f0bc297a632766b6"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c558b50402fca1acc94329c5d8f12aa429738904a5cfb32b9ed3c61235221bb"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:20bafc4095eab00f41a510579363a3f5e1f5c69d7ee10f1d88895c4df0259183"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f619fd38fc2641abfb53cca719c165182500600b82c695cc548a0f05f764be05"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:044447ae4b2016a6b8697571fd633f799f860b19b76c4a2fd9b1140d52ee6745"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:49d30ba7074f469e8167917abf9eb854c6503ae10153034a6d4df33618f1db5f"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:48400b96788cdaca647021bf19a9cd668384f46e4d9c55cf045bdd17f65299c8"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-win32.whl", hash = "sha256:8a68f57b7a3f7b6b52ada79876be1efb97c8c0952423436e84d70cc139f16f0d"},
-    {file = "pyzmq-23.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9e5bf6e7239fc9687239de7a283aa8b801ab85371116045b33ae20132a1325d6"},
-    {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:0ff6294e001129a9f22dcbfba186165c7e6f573c46de2704d76f873c94c65416"},
-    {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffc6b1623d0f9affb351db4ca61f432dca3628a5ee015f9bf2bfbe9c6836881c"},
-    {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d6f110c56f7d5b4d64dde3a382ae61b6d48174e30742859d8e971b18b6c9e5c"},
-    {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9269fbfe3a4eb2009199120861c4571ef1655fdf6951c3e7f233567c94e8c602"},
-    {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12e62ff0d5223ec09b597ab6d73858b9f64a51221399f3cb08aa495e1dff7935"},
-    {file = "pyzmq-23.2.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6fd5d0d50cbcf4bc376861529a907bed026a4cbe8c22a500ff8243231ef02433"},
-    {file = "pyzmq-23.2.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9d0ab2936085c85a1fc6f9fd8f89d5235ae99b051e90ec5baa5e73ad44346e1f"},
-    {file = "pyzmq-23.2.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:022cf5ea7bcaa8a06a03c2706e0ae66904b6138b2155577cd34c64bc7cc637ab"},
-    {file = "pyzmq-23.2.1-cp38-cp38-win32.whl", hash = "sha256:28dbdb90b2f6b131f8f10e6081012e4e25234213433420e67e0c1162de537113"},
-    {file = "pyzmq-23.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:10d1910ec381b851aeb024a042a13db178cb1edf125e76a4e9d2548ad103aadb"},
-    {file = "pyzmq-23.2.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:99a5a77a10863493a1ee8dece02578c6b32025fb3afff91b40476bc489e81648"},
-    {file = "pyzmq-23.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:aecd6ceaccc4b594e0092d6513ef3f1c0fa678dd89f86bb8ff1a47014b8fca35"},
-    {file = "pyzmq-23.2.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:415ff62ac525d9add1e3550430a09b9928d2d24a20cc4ce809e67caac41219ab"},
-    {file = "pyzmq-23.2.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:67975a9e1237b9ccc78f457bef17691bbdd2055a9d26e81ee914ba376846d0ce"},
-    {file = "pyzmq-23.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38e106b64bad744fe469dc3dd864f2764d66399178c1bf39d45294cc7980f14f"},
-    {file = "pyzmq-23.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c842109d31a9281d678f668629241c405928afbebd913c48a5a8e7aee61f63d"},
-    {file = "pyzmq-23.2.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:fefdf9b685fda4141b95ebec975946076a5e0723ff70b037032b2085c5317684"},
-    {file = "pyzmq-23.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:79a87831b47a9f6161ad23fa5e89d5469dc585abc49f90b9b07fea8905ae1234"},
-    {file = "pyzmq-23.2.1-cp39-cp39-win32.whl", hash = "sha256:342ca3077f47ec2ee41b9825142b614e03e026347167cbc72a59b618c4f6106c"},
-    {file = "pyzmq-23.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:5e05492be125dce279721d6b54fd1b956546ecc4bcdfcf8e7b4c413bc0874c10"},
-    {file = "pyzmq-23.2.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:07ed8aaf7ffe150af873269690cc654ffeca7491f62aae0f3821baa181f8d5fe"},
-    {file = "pyzmq-23.2.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad28ddb40db8e450d7d4bf8a1d765d3f87b63b10e7e9a825a3c130c6371a8c03"},
-    {file = "pyzmq-23.2.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2f67b63f53c6994d601404fd1a329e6d940ac3dd1d92946a93b2b9c70df67b9f"},
-    {file = "pyzmq-23.2.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c890309296f53f9aa32ffcfc51d805705e1982bffd27c9692a8f1e1b8de279f4"},
-    {file = "pyzmq-23.2.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:624fd38071a817644acdae075b92a23ea0bdd126a58148288e8284d23ec361ce"},
-    {file = "pyzmq-23.2.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a114992a193577cb62233abf8cb2832970f9975805a64740e325d2f895e7f85a"},
-    {file = "pyzmq-23.2.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c780acddd2934c6831ff832ecbf78a45a7b62d4eb216480f863854a8b7d54fa7"},
-    {file = "pyzmq-23.2.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d904f6595acfaaf99a1a61881fea068500c40374d263e5e073aa4005e5f9c28a"},
-    {file = "pyzmq-23.2.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:929d548b74c0f82f7f95b54e4a43f9e4ce2523cfb8a54d3f7141e45652304b2a"},
-    {file = "pyzmq-23.2.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:f392cbea531b7142d1958c0d4a0c9c8d760dc451e5848d8dd3387804d3e3e62c"},
-    {file = "pyzmq-23.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a0f09d85c45f58aa8e715b42f8b26beba68b3b63a8f7049113478aca26efbc30"},
-    {file = "pyzmq-23.2.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23e708fbfdf4ee3107422b69ca65da1b9f056b431fc0888096a8c1d6cd908e8f"},
-    {file = "pyzmq-23.2.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35e635343ff367f697d00fa1484262bb68e36bc74c9b80737eac5a1e04c4e1b1"},
-    {file = "pyzmq-23.2.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efb9e38b2a590282704269585de7eb33bf43dc294cad092e1b172e23d4c217e5"},
-    {file = "pyzmq-23.2.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:407f909c4e8fde62fbdad9ebd448319792258cc0550c2815567a4d9d8d9e6d18"},
-    {file = "pyzmq-23.2.1.tar.gz", hash = "sha256:2b381aa867ece7d0a82f30a0c7f3d4387b7cf2e0697e33efaa5bed6c5784abcd"},
+    {file = "pyzmq-24.0.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:38e9ff2918d50a588e56aa80dae0373ef9f67512fc5691f95db2f59edabc083e"},
+    {file = "pyzmq-24.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5439bef77fd3818c20e1bf5657836e105e4e48e1a7996e24ebb55402a681934e"},
+    {file = "pyzmq-24.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e24d7bda7a32ff35d0c914a52dd920a408f73d7e4b93d6755d7c67e819a8cd8c"},
+    {file = "pyzmq-24.0.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0775b65e79cccfca2b017e80ffe6dbd224b035a47245c4140b08e93996425942"},
+    {file = "pyzmq-24.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2e5a398955b1cfdd85dd699f2390661b7bbe9edcbadd70a444c79c69e6c31c91"},
+    {file = "pyzmq-24.0.0-cp310-cp310-win32.whl", hash = "sha256:1bdec8988cad1f9a8453b4d00fd11598a91604cd9b205640e98b2f22e0435921"},
+    {file = "pyzmq-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:eadf1d3841c2155b68ef49147253fd4ac1447a972d01c08248114edc4d3ba9d5"},
+    {file = "pyzmq-24.0.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:99bb8cff279f7d1f516919d82b35ed0796c53ce7da7dca191fabfa4c53f47740"},
+    {file = "pyzmq-24.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:452c3d5bfbaf96f32ef20673e6ba238355891884009f0c87e0f97a985293ef42"},
+    {file = "pyzmq-24.0.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9cd5c7449f297a1b53a4803413db907a8cad1178435e2879c1b92816f2bbe56"},
+    {file = "pyzmq-24.0.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f200cdca2fc842749a3f263ccf9e4b50e732ad14f53b60faf68ef656b75c32a"},
+    {file = "pyzmq-24.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ae33cb195304ac16996184b115f9e27eb9f0b14062e97fbd1d446e3e4a594ff0"},
+    {file = "pyzmq-24.0.0-cp311-cp311-win32.whl", hash = "sha256:62ee069fe338d0b057b81e752dad2b9b6b206ba8570a878dbbe8b93b7b99ebb1"},
+    {file = "pyzmq-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:e9e3fa94fa1e58763a7b824b8e0015d93c9fdd8e449d0218d13d01172e3d1539"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b94a3453a18bb914b2cac1ac38c09f980a3c86a8cd0bb744dd6bd03ab8ff958a"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:44c1dc858b76d2ab28f5ea040dd5e816a71624a8cf38d4ca3208006fd2a9375e"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:40cdb50e82393253d340b6a357474588eb01cfd90b06231d5bfbc14490490b1b"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:eb3b8acb5dc33ec812d79f35b85fddc43d8f75b65c00c635ee3c0b527e11c8ea"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-win32.whl", hash = "sha256:8988209d5efae9b5c9297fb48d153e2528384c1afe2c9fd8eeb474cd6e765199"},
+    {file = "pyzmq-24.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52d881c33f8db5ffcb0aabc14cc71098453f4700511195cebca846000b44b080"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:844040d44cc4320cdffb258fe03768ff0b37e710d56a70dd1f6c2902738f1e28"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ff4e510a9509d36359c7af4684e73489cdd53c781dd4bc9b07dc808fab56cc48"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:a5cdbede23aae133e50f786adc4a2cacf60bddde649e3dc122c32368daa2c007"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ee24b94b5ae22af9148e597f512fae8383908ca07d3b7f99b349679fede4d7d3"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-win32.whl", hash = "sha256:c37c0046d04c0fdd99a9a31d6a9ce7d703cca3b7fdde5738603503dfba58a25f"},
+    {file = "pyzmq-24.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b1ef471c62c3d0681cfbaa8bbaf96f22e20cafd391ecad8a43317f6b1598478e"},
+    {file = "pyzmq-24.0.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:dfde6624d3d99d9a67235b60ae13be1a6ffce2f1de3cd2be9900f011d5d6a6a6"},
+    {file = "pyzmq-24.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fc2c363f68bbb9fea6b8137c432c6df9d7c8c76b01549c4410c506dac9e30663"},
+    {file = "pyzmq-24.0.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6814a6add1b7cb76e3fdfd961ce4c48c1f0a29e82bdb3d060a669b85bc6db454"},
+    {file = "pyzmq-24.0.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3823e5e613a61948b2e6b85fd91f872772717d24cd1df871836665d4c56d6b34"},
+    {file = "pyzmq-24.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1c23568e1581f637b1a1e1fd15dcd5e9165332c94bf8101c562e7c50640d673e"},
+    {file = "pyzmq-24.0.0-cp38-cp38-win32.whl", hash = "sha256:8a93abd67a46c6b91f28a7513b9f8b9a5432fd573c3d6444c083e07209bf96e4"},
+    {file = "pyzmq-24.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:8361c90701fc6ff5f16c81c969563c6915402fbecb2ddc9c5063fec0238e5e52"},
+    {file = "pyzmq-24.0.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:4ec8847ab93200a94fd3e88e2824a6bba9a46d28161f1bf0be24f2237c40c291"},
+    {file = "pyzmq-24.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f969214a9ebf1175a8aba863d6f1220174130188686d4ed475d138a240e60c1c"},
+    {file = "pyzmq-24.0.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a07fb73ae006a5b565d19232e5a6592fd7c93e57e67c2e592bf0b21f1676767"},
+    {file = "pyzmq-24.0.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0128c7b723984e31c1b0df5bc532715defd13bf64d8d9eddd7207d093759ae4"},
+    {file = "pyzmq-24.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ed10f5a942a2903a722d63806b7a9d2e0a966c038100dc763483d8fbe8ea074"},
+    {file = "pyzmq-24.0.0-cp39-cp39-win32.whl", hash = "sha256:201e4d5733cecfd469d9ceee57500a0f365f85d6f14dd524105e2a0be8cd93c1"},
+    {file = "pyzmq-24.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:460f0ff945d4b46c2d568941be33cf08954fca1e3239cf6a6ee03b1371de8f64"},
+    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebdb43e947291c5cb80ef6c7d525f64bc4ed685de43f855ba0cf2b0fd8052e3a"},
+    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0584420cbd2dac77f81bdc4b9da2635a54300563d4632433b08cb1f505341ef0"},
+    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:be67e7f48fce8dbefd602f779c7382c874a1a1a3d08f375366c4d28baaa0bfd4"},
+    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a5b9471e5e507f51f4c0acabec60a7ae2ea218ac6134a8e5ec5674845347a63a"},
+    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc21a74f337298840f59f21a12fbf6ec1de798cd69d6b331ef9ed88ac8cb18f0"},
+    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:aa6d0dfa94ce89d050dca0104389e10c537715bf10e5b0bfe5ece79f17f1719e"},
+    {file = "pyzmq-24.0.0.tar.gz", hash = "sha256:13b008bd142c9f6079ad75a30504eef2291502e9eac90e722b16fcf9ce856147"},
 ]
 quantities = [
     {file = "quantities-0.13.0.tar.gz", hash = "sha256:0fde20115410de21cefa786f3aeae69c1b51bb19ee492190324c1da705e61a81"},
@@ -2280,12 +2443,20 @@ scipy = [
     {file = "scipy-1.5.4.tar.gz", hash = "sha256:4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b"},
 ]
 setuptools = [
-    {file = "setuptools-59.6.0-py3-none-any.whl", hash = "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"},
-    {file = "setuptools-59.6.0.tar.gz", hash = "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373"},
+    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
+    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
+]
+setuptools-scm = [
+    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
+    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 sympy = [
     {file = "sympy-1.9-py3-none-any.whl", hash = "sha256:8bc5de4608b7aa4e7ffd1b25452ae87ccc5f6ca667c661aafb854a1ade337d0c"},
@@ -2308,63 +2479,33 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
-    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 toolz = [
     {file = "toolz-0.12.0-py3-none-any.whl", hash = "sha256:2059bd4148deb1884bb0eb770a3cde70e7f954cfbbdc2285f1f2de01fd21eb6f"},
     {file = "toolz-0.12.0.tar.gz", hash = "sha256:88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194"},
 ]
 tornado = [
-    {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b"},
-    {file = "tornado-6.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675"},
-    {file = "tornado-6.1-cp35-cp35m-win32.whl", hash = "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5"},
-    {file = "tornado-6.1-cp35-cp35m-win_amd64.whl", hash = "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68"},
-    {file = "tornado-6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c"},
-    {file = "tornado-6.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085"},
-    {file = "tornado-6.1-cp36-cp36m-win32.whl", hash = "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575"},
-    {file = "tornado-6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795"},
-    {file = "tornado-6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01"},
-    {file = "tornado-6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d"},
-    {file = "tornado-6.1-cp37-cp37m-win32.whl", hash = "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df"},
-    {file = "tornado-6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37"},
-    {file = "tornado-6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95"},
-    {file = "tornado-6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a"},
-    {file = "tornado-6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f"},
-    {file = "tornado-6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6"},
-    {file = "tornado-6.1-cp38-cp38-win32.whl", hash = "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326"},
-    {file = "tornado-6.1-cp38-cp38-win_amd64.whl", hash = "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c"},
-    {file = "tornado-6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5"},
-    {file = "tornado-6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe"},
-    {file = "tornado-6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0"},
-    {file = "tornado-6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd"},
-    {file = "tornado-6.1-cp39-cp39-win32.whl", hash = "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c"},
-    {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
-    {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
+    {file = "tornado-6.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:20f638fd8cc85f3cbae3c732326e96addff0a15e22d80f049e00121651e82e72"},
+    {file = "tornado-6.2-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:87dcafae3e884462f90c90ecc200defe5e580a7fbbb4365eda7c7c1eb809ebc9"},
+    {file = "tornado-6.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba09ef14ca9893954244fd872798b4ccb2367c165946ce2dd7376aebdde8e3ac"},
+    {file = "tornado-6.2-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8150f721c101abdef99073bf66d3903e292d851bee51910839831caba341a75"},
+    {file = "tornado-6.2-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3a2f5999215a3a06a4fc218026cd84c61b8b2b40ac5296a6db1f1451ef04c1e"},
+    {file = "tornado-6.2-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5f8c52d219d4995388119af7ccaa0bcec289535747620116a58d830e7c25d8a8"},
+    {file = "tornado-6.2-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:6fdfabffd8dfcb6cf887428849d30cf19a3ea34c2c248461e1f7d718ad30b66b"},
+    {file = "tornado-6.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:1d54d13ab8414ed44de07efecb97d4ef7c39f7438cf5e976ccd356bebb1b5fca"},
+    {file = "tornado-6.2-cp37-abi3-win32.whl", hash = "sha256:5c87076709343557ef8032934ce5f637dbb552efa7b21d08e89ae7619ed0eb23"},
+    {file = "tornado-6.2-cp37-abi3-win_amd64.whl", hash = "sha256:e5f923aa6a47e133d1cf87d60700889d7eae68988704e20c75fb2d65677a8e4b"},
+    {file = "tornado-6.2.tar.gz", hash = "sha256:9b630419bde84ec666bfd7ea0a4cb2a8a651c2d5cccdbdd1972a0c859dfc3c13"},
 ]
 tqdm = [
     {file = "tqdm-4.64.1-py2.py3-none-any.whl", hash = "sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1"},
     {file = "tqdm-4.64.1.tar.gz", hash = "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"},
 ]
 traitlets = [
-    {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
-    {file = "traitlets-4.3.3.tar.gz", hash = "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"},
+    {file = "traitlets-5.4.0-py3-none-any.whl", hash = "sha256:93663cc8236093d48150e2af5e2ed30fc7904a11a6195e21bab0408af4e6d6c8"},
+    {file = "traitlets-5.4.0.tar.gz", hash = "sha256:3f2c4e435e271592fe4390f1746ea56836e3a080f84e7833f0f801d9613fec39"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
@@ -2393,8 +2534,8 @@ typed-ast = [
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
@@ -2436,10 +2577,10 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 Werkzeug = [
-    {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},
-    {file = "Werkzeug-2.0.3.tar.gz", hash = "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"},
+    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
+    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
 ]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ documentation = "https://pyrfume.readthedocs.io"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4.0"
+python = ">=3.7,<3.10"
 deap = { version = "^1.3.1", optional = true }
 eden-kernel = "^0.3.1348"
 mordred = "^1.2.0"
@@ -25,7 +25,7 @@ requests = ">=2.20.0,<=2.27.1"
 scikit-learn = ">=0.23.1,<=0.24.2"
 scipy = ">=1.4.1,<=1.5.4"
 sympy = ">=1.6,<=1.9"
-pandas = "1.0.5"
+pandas = ">1.0.5"
 ipykernel = ">=5.5.6,<6.15.1"
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,5 +55,5 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["poetry-core>=1.0.8"]
+requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ exclude = '''
 )/
 '''
 
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyrfume/__init__.py
+++ b/pyrfume/__init__.py
@@ -1,3 +1,2 @@
-from .base import *  # noqa: F401
-from .odorants import from_cids, get_cids  # noqa: F401
-
+from .base import *
+from .odorants import from_cids, get_cids

--- a/pyrfume/__init__.py
+++ b/pyrfume/__init__.py
@@ -1,2 +1,3 @@
-from .base import *
-from .odorants import from_cids, get_cids
+from .base import *  # noqa: F401
+from .odorants import from_cids, get_cids  # noqa: F401
+

--- a/pyrfume/__init__.py
+++ b/pyrfume/__init__.py
@@ -1,2 +1,2 @@
 from .base import *
-from .odorants import get_cids, from_cids
+from .odorants import from_cids, get_cids

--- a/pyrfume/__init__.py
+++ b/pyrfume/__init__.py
@@ -1,3 +1,2 @@
 from .base import *
 from .odorants import get_cids, from_cids
-

--- a/pyrfume/base.py
+++ b/pyrfume/base.py
@@ -1,19 +1,19 @@
 import configparser
 import json
 import logging
+import pickle
+import re
+import tempfile
+import urllib
+from pathlib import Path
+from pprint import pprint
+from typing import Any, Dict, Iterable, List, Union
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
-import pickle
-from pprint import pprint
-import re
 import requests
-import tempfile
 import toml
 from tqdm.auto import tqdm, trange
-from typing import Any, Iterable, List, Dict, Union
-import urllib
-
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = PACKAGE_DIR / "config.ini"

--- a/pyrfume/base.py
+++ b/pyrfume/base.py
@@ -18,11 +18,11 @@ import urllib
 PACKAGE_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = PACKAGE_DIR / "config.ini"
 DEFAULT_DATA_PATH = PACKAGE_DIR.parent.parent / "pyrfume-data"
-REMOTE_DATA_ORG = 'pyrfume'
-REMOTE_DATA_REPO = 'pyrfume-data'
-REMOTE_DATA_PATH = 'https://raw.githubusercontent.com/%s/%s' % (REMOTE_DATA_ORG, REMOTE_DATA_REPO)
+REMOTE_DATA_ORG = "pyrfume"
+REMOTE_DATA_REPO = "pyrfume-data"
+REMOTE_DATA_PATH = "https://raw.githubusercontent.com/%s/%s" % (REMOTE_DATA_ORG, REMOTE_DATA_REPO)
 TEMP_LOCAL = tempfile.TemporaryDirectory()
-MANIFEST_NAME = 'manifest.toml'
+MANIFEST_NAME = "manifest.toml"
 
 
 class LocalDataError(Exception):
@@ -36,7 +36,7 @@ class RemoteDataError(Exception):
 logger = logging.getLogger("pyrfume")
 
 
-def init_config(overwrite: bool=False):
+def init_config(overwrite: bool = False):
     if overwrite or not CONFIG_PATH.exists():
         config = configparser.ConfigParser()
         config["PATHS"] = {"pyrfume-data": str(DEFAULT_DATA_PATH)}
@@ -65,7 +65,7 @@ def write_config(header: str, key: str, value: Any):
         config.write(f)
 
 
-def set_data_path(path: str, create: bool=True):
+def set_data_path(path: str, create: bool = True):
     path = Path(path).resolve()
     if create:
         path.mkdir(exist_ok=True, parents=True)
@@ -74,7 +74,7 @@ def set_data_path(path: str, create: bool=True):
     write_config("PATHS", "pyrfume-data", str(path))
 
 
-def get_data_path(create: bool=True) -> str:
+def get_data_path(create: bool = True) -> str:
     path = read_config("PATHS", "pyrfume-data")
     path = Path(path).resolve()
     if create:
@@ -84,99 +84,105 @@ def get_data_path(create: bool=True) -> str:
     return path
 
 
-def get_remote_data_path(branch='main'):
-    path = REMOTE_DATA_PATH + '/' + branch
+def get_remote_data_path(branch="main"):
+    path = REMOTE_DATA_PATH + "/" + branch
     return path
 
 
-def localize_remote_data(rel_path: str, branch: str='main', quiet: bool=False) -> str:
-    url = get_remote_data_path(branch=branch) + '/' + rel_path
+def localize_remote_data(rel_path: str, branch: str = "main", quiet: bool = False) -> str:
+    url = get_remote_data_path(branch=branch) + "/" + rel_path
     target_path = Path(TEMP_LOCAL.name) / rel_path
     response = requests.get(url)
     if response.status_code != 200:
         if not quiet:
-            raise RemoteDataError('Could not get file at %s' % url)
+            raise RemoteDataError("Could not get file at %s" % url)
         else:
             return None
     target_path.parent.mkdir(exist_ok=True)
-    with open(target_path, 'wb') as f:
+    with open(target_path, "wb") as f:
         f.write(response.content)
     return target_path
 
 
-def get_remote_archives_info(branch: str='main') -> dict:
-    url = 'https://api.github.com/repos/%s/%s/git/trees/%s' % (REMOTE_DATA_ORG, REMOTE_DATA_REPO, branch)
+def get_remote_archives_info(branch: str = "main") -> dict:
+    url = "https://api.github.com/repos/%s/%s/git/trees/%s" % (
+        REMOTE_DATA_ORG,
+        REMOTE_DATA_REPO,
+        branch,
+    )
     response = requests.get(url)
     if response.status_code != 200:
-        raise RemoteDataError('Could not get archive list at %s' % url)
+        raise RemoteDataError("Could not get archive list at %s" % url)
     info = json.loads(response.content)
     return info
 
-    
-def list_archives(branch: str='main', remote: bool=None) -> List[str]:
+
+def list_archives(branch: str = "main", remote: bool = None) -> List[str]:
     archives = []
     if remote:
         info = get_remote_archives_info(branch=branch)
-        for item in info['tree']:
-            if item['type'] == 'tree':
-                archives.append(item['path'])    
+        for item in info["tree"]:
+            if item["type"] == "tree":
+                archives.append(item["path"])
     else:
         path = get_data_path()
         for directory in path.iterdir():
-            if (directory / 'manifest.toml').is_file():
+            if (directory / "manifest.toml").is_file():
                 archives.append(directory.name)
         if not len(archives):
             f = logger.info if remote is None else logger.warning
-            f('No local archives found; searching remotely...')
+            f("No local archives found; searching remotely...")
             return list_archives(branch=branch, remote=True)
     archives = sorted(archives)
     return archives
-    
-    
-def load_manifest(archive_name: str, remote: bool=None) -> dict:
-    rel_path = archive_name + '/' + MANIFEST_NAME 
+
+
+def load_manifest(archive_name: str, remote: bool = None) -> dict:
+    rel_path = archive_name + "/" + MANIFEST_NAME
     return load_data(rel_path, remote=remote)
 
 
-def show_files(archive_name: str, remote: bool=None, raw: bool=False):
+def show_files(archive_name: str, remote: bool = None, raw: bool = False):
     manifest = load_manifest(archive_name, remote=remote)
-    items = manifest['processed']
+    items = manifest["processed"]
     if raw:
-        items.update(manifest['raw'])
+        items.update(manifest["raw"])
     pprint(items)
-    
-    
+
+
 def resolve_lfs(df: pd.DataFrame) -> pd.DataFrame:
     """Resolve the full dataframe if the current one is a git-LFS pointer files."""
-    if 'git-lfs' in (df.index.name or ''):
-        match = re.search('(?<=sha256:).*$', df.index[0])
+    if "git-lfs" in (df.index.name or ""):
+        match = re.search("(?<=sha256:).*$", df.index[0])
         if match:
             sha = match.group(0)
-            lookup = load_data('lfs-cache.csv')
-            url = lookup.loc[sha, 'url']
+            lookup = load_data("lfs-cache.csv")
+            url = lookup.loc[sha, "url"]
             df = pd.read_csv(url, index_col=0)
     return df
-    
-    
-def load_data(rel_path: str, remote: str=None, cids: Iterable=None, quiet: bool=False, **kwargs) -> Union[pd.DataFrame, dict]:
+
+
+def load_data(
+    rel_path: str, remote: str = None, cids: Iterable = None, quiet: bool = False, **kwargs
+) -> Union[pd.DataFrame, dict]:
     if remote:
         full_path = localize_remote_data(rel_path, quiet=quiet)
     else:
         full_path = get_data_path() / rel_path
         if not full_path.exists():
             if remote is None:
-                logger.info('Did not find file %s locally; fetching remotely.' % full_path)
+                logger.info("Did not find file %s locally; fetching remotely." % full_path)
                 return load_data(rel_path, remote=True, quiet=quiet, **kwargs)
             elif not quiet:
-                raise LocalDataError('Could not get file at %s' % full_path)
+                raise LocalDataError("Could not get file at %s" % full_path)
     if not full_path:
         return None
-    
+
     is_csv = full_path.suffix in [".csv", ".txt"]
     is_pickle = full_path.suffix in [".pkl", ".pickle", ".p"]
-    is_excel = full_path.suffix in  [".xls", ".xlsx"]
+    is_excel = full_path.suffix in [".xls", ".xlsx"]
     is_manifest = full_path.suffix == Path(MANIFEST_NAME).suffix
-    
+
     if is_pickle:
         with open(full_path, "rb") as f:
             data = pickle.load(f)
@@ -187,21 +193,24 @@ def load_data(rel_path: str, remote: str=None, cids: Iterable=None, quiet: bool=
             kwargs["index_col"] = 0
         if cids:
             # First check for a CIDs file specific to this dataset
-            cids_path = str(Path(rel_path).parent / 'molecules.csv')
+            cids_path = str(Path(rel_path).parent / "molecules.csv")
             cids_data = load_data(cids_path, remote=remote, quiet=True)
             if cids_data is not None:
                 all_cids_ = cids_data.index.tolist()
             else:
                 # If not found, fall back on the generic Pyrfume list of CIDs
                 from pyrfume.odorants import all_cids
-                all_cids_ = all_cids() # Thousands of CIDs to choose from.
-            skip_f = lambda line_num: False if not line_num else all_cids_[line_num-1] not in cids
-            kwargs['skiprows'] = skip_f
+
+                all_cids_ = all_cids()  # Thousands of CIDs to choose from.
+            skip_f = lambda line_num: False if not line_num else all_cids_[line_num - 1] not in cids
+            kwargs["skiprows"] = skip_f
         data = pd.read_csv(full_path, **kwargs)
         if cids and sorted(data.index.tolist()) != sorted(cids):
-            logger.warning('CIDs returned did not match CIDs requested; does this dataset have a custom CID list?')
+            logger.warning(
+                "CIDs returned did not match CIDs requested; does this dataset have a custom CID list?"
+            )
     elif is_manifest:
-        with open(full_path, 'r') as f:
+        with open(full_path, "r") as f:
             data = toml.load(f)
     else:
         raise LocalDataError("%s has an unknown data type" % rel_path)
@@ -215,7 +224,7 @@ def load_data(rel_path: str, remote: str=None, cids: Iterable=None, quiet: bool=
     return data
 
 
-def save_data(data: pd.DataFrame, rel_path: str, create_archive: bool=True, **kwargs):
+def save_data(data: pd.DataFrame, rel_path: str, create_archive: bool = True, **kwargs):
     full_path = get_data_path() / rel_path
     is_pickle = any(str(full_path).endswith(x) for x in (".pkl", ".pickle", ".p"))
     is_csv = any(str(full_path).endswith(x) for x in (".csv"))
@@ -224,7 +233,10 @@ def save_data(data: pd.DataFrame, rel_path: str, create_archive: bool=True, **kw
         if create_archive:
             archive_path.mkdir(exist_ok=True)
         else:
-            raise LocalDataError("Archive %s does not exist; use `create_archive=True` to create it" % archive_path.name)
+            raise LocalDataError(
+                "Archive %s does not exist; use `create_archive=True` to create it"
+                % archive_path.name
+            )
     if is_pickle:
         with open(full_path, "wb") as f:
             pickle.dump(data, f)

--- a/pyrfume/base.py
+++ b/pyrfume/base.py
@@ -4,16 +4,13 @@ import logging
 import pickle
 import re
 import tempfile
-import urllib
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Iterable, List, Union
 
-import numpy as np
 import pandas as pd
 import requests
 import toml
-from tqdm.auto import tqdm, trange
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 CONFIG_PATH = PACKAGE_DIR / "config.ini"
@@ -162,7 +159,7 @@ def resolve_lfs(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def load_data(
+def load_data(  # noqa: C901 (too complex -- TODO)
     rel_path: str, remote: str = None, cids: Iterable = None, quiet: bool = False, **kwargs
 ) -> Union[pd.DataFrame, dict]:
     if remote:
@@ -202,7 +199,7 @@ def load_data(
                 from pyrfume.odorants import all_cids
 
                 all_cids_ = all_cids()  # Thousands of CIDs to choose from.
-            skip_f = lambda line_num: False if not line_num else all_cids_[line_num - 1] not in cids
+            skip_f = lambda line_num: False if not line_num else all_cids_[line_num - 1] not in cids  # noqa: E731 (don't assign lambda -- TODO)
             kwargs["skiprows"] = skip_f
         data = pd.read_csv(full_path, **kwargs)
         if cids and sorted(data.index.tolist()) != sorted(cids):

--- a/pyrfume/base.py
+++ b/pyrfume/base.py
@@ -199,7 +199,9 @@ def load_data(  # noqa: C901 (too complex -- TODO)
                 from pyrfume.odorants import all_cids
 
                 all_cids_ = all_cids()  # Thousands of CIDs to choose from.
-            skip_f = lambda line_num: False if not line_num else all_cids_[line_num - 1] not in cids  # noqa: E731 (don't assign lambda -- TODO)
+            skip_f = (
+                lambda line_num: False if not line_num else all_cids_[line_num - 1] not in cids
+            )  # noqa: E73
             kwargs["skiprows"] = skip_f
         data = pd.read_csv(full_path, **kwargs)
         if cids and sorted(data.index.tolist()) != sorted(cids):

--- a/pyrfume/cleaning.py
+++ b/pyrfume/cleaning.py
@@ -1,9 +1,8 @@
 import os
 
 import pandas as pd
-from sklearn.preprocessing import StandardScaler
-
 from missingpy import KNNImputer
+from sklearn.preprocessing import StandardScaler
 
 from .base import DATA_DIR
 

--- a/pyrfume/datajoint_tools.py
+++ b/pyrfume/datajoint_tools.py
@@ -4,7 +4,9 @@ import re
 from importlib import import_module
 from inspect import isclass
 from typing import Any, ForwardRef, _GenericAlias
+
 import datajoint as dj
+
 from .dbtables import QuantityAdapter
 
 dj.errors._switch_adapted_types(True)
@@ -198,7 +200,7 @@ if __name__ == "__main__":
     set_dj_definition(Stuff)
 
     # Schematize each of these classes (will include foreign keys)
-    from pyrfume.odorants import Molecule, Vendor, ChemicalOrder
+    from pyrfume.odorants import ChemicalOrder, Molecule, Vendor
 
     schema = dj.schema("u_%s_odorants" % dj.config["database.user"], locals())
 

--- a/pyrfume/dbtables.py
+++ b/pyrfume/dbtables.py
@@ -13,8 +13,8 @@ schema = None
 
 
 def set_schema_name(new_schema_name: str) -> None:
-    """ Set a new schema name into the config file. The data saved 
-        into the old schema will be keeped on the server unless 
+    """Set a new schema name into the config file. The data saved
+        into the old schema will be keeped on the server unless
         `drop_schema` was called.
 
     Args:
@@ -25,8 +25,8 @@ def set_schema_name(new_schema_name: str) -> None:
 
 
 def init_schema() -> None:
-    """ Get the name of schema from the config file 
-        and initialize the schema with it.
+    """Get the name of schema from the config file
+    and initialize the schema with it.
     """
 
     schema_name = read_config("DATABASE", "schema_name")
@@ -36,14 +36,14 @@ def init_schema() -> None:
     context = globals()
     global schema
     schema = dj.schema(schema_name, context)
-    schema.context.update({'quantity_adapter': QuantityAdapter()})
+    schema.context.update({"quantity_adapter": QuantityAdapter()})
 
 
 def drop_schema(force=False) -> None:
     """Drop the datajoint schema.
 
     Args:
-        force (bool, optional): Dropping it without a pop up confirmation. 
+        force (bool, optional): Dropping it without a pop up confirmation.
         Defaults to False.
     """
 
@@ -55,7 +55,7 @@ def drop_schema(force=False) -> None:
 
 
 def get_table(table_name: str) -> UserTable:
-    """ Get a single datajoint table by table name.
+    """Get a single datajoint table by table name.
 
     Args:
         table_name (str): The name of the datajoint table.
@@ -80,7 +80,7 @@ def get_table(table_name: str) -> UserTable:
 
 
 def get_tables() -> Dict[str, UserTable]:
-    """ Get all datajoint tables in this module.
+    """Get all datajoint tables in this module.
 
     Returns:
         Dict[str, UserTable]: The dict that contains all the table classes.
@@ -93,16 +93,17 @@ def get_tables() -> Dict[str, UserTable]:
     result = {}
     for key, value in globals().items():
         if inspect.isclass(value) and value is not QuantityAdapter and value is not UserTable:
-            result[key] = (schema(value))
+            result[key] = schema(value)
 
     return result
 
 
 class QuantityAdapter(dj.AttributeAdapter):
-    """ The datajoint adapter class that puts and gets Python Quantity objects 
-        to and from the datajoint database server.
+    """The datajoint adapter class that puts and gets Python Quantity objects
+    to and from the datajoint database server.
     """
-    attribute_type = 'float'
+
+    attribute_type = "float"
 
     def put(self, obj: pq.Quantity):
         assert isinstance(obj, pq.Quantity)
@@ -114,7 +115,7 @@ class QuantityAdapter(dj.AttributeAdapter):
 
 
 class Molecule(dj.Manual):
-    definition = '''
+    definition = """
     smiles : varchar(25)
     ---
     inchi = NULL : varchar(128)
@@ -122,164 +123,164 @@ class Molecule(dj.Manual):
     pubchem_id = NULL : int
     name = "" : varchar(128)
     iupac = "" : varchar(128)
-    '''
+    """
 
 
 class Vendor(dj.Manual):
-    definition = '''
+    definition = """
     name = "" : varchar(256)
     ---
-    '''
+    """
 
 
 class Product(dj.Manual):
-    definition = '''
+    definition = """
     -> Vendor 
     catalog = 0 : int
     ---
     -> Molecule
     purity = "" : varchar(64)
     batch = "" : varchar(64)
-    '''
+    """
 
 
 class Compound(dj.Manual):
-    definition = '''
+    definition = """
     -> Product
     date_delivered : datetime
     location = "" : varchar(64)
     ---
     date_opened = NULL : datetime
-    '''
+    """
 
 
 class Solution(dj.Manual):
-    definition = '''
+    definition = """
     solution_id: int auto_increment
     ---
     diution = NULL : int
     concentration = NULL : float
     value = NULL : <quantity_adapter>
     mixing_data = NULL : date
-    '''
+    """
 
     class Compounds(dj.Part):
-        definition = '''
+        definition = """
         -> Solution
         -> Compound
         ---
-        '''
+        """
 
 
 class Vessel(dj.Manual):
-    definition = '''
+    definition = """
     name = "" : varchar(64)
     height = 0 : float
     base_area = "" : varchar(64)
     ---
-    '''
+    """
 
 
 class Odorant(dj.Manual):
-    definition = '''
+    definition = """
     odorant_id: int auto_increment
     ---
     -> Vessel
     date_prepared = NULL : datetime
-    '''
+    """
 
     class Solutions(dj.Part):
-        definition = '''
+        definition = """
         -> Odorant
         -> Solution
         ---
-        '''
+        """
 
 
 class Route(dj.Manual):
-    definition = '''
+    definition = """
     route_id: int auto_increment
     ---
     name = "" : varchar(64)
-    '''
+    """
 
 
 class Stimulus(dj.Manual):
-    definition = '''
+    definition = """
     stimulus_id: int auto_increment
     ---
     -> Route
-    '''
+    """
 
     class Odorants(dj.Part):
-        definition = '''
+        definition = """
         -> Stimulus
         -> Odorant
         ---
-        '''
+        """
 
 
 class Subject(dj.Manual):
-    definition = '''
+    definition = """
     subject_id: int auto_increment
     ---
     age : tinyint
     gender : tinyint
     detail_info : varchar(512)
-    '''
+    """
 
 
 class Trial(dj.Manual):
-    definition = '''
+    definition = """
     trial_id: int auto_increment
     ---
     -> Stimulus
     -> Subject
     time : timestamp
-    '''
+    """
 
 
 class Site(dj.Manual):
-    definition = '''
+    definition = """
     site_id: int auto_increment
     ---
     name : varchar(64)
     kind : varchar(16)
-    '''
+    """
 
 
 class Investigator(dj.Manual):
-    definition = '''
+    definition = """
     investigator_id: int auto_increment
     ---
     first_name : varchar(64)
     last_name : varchar(64)
     -> Site
-    '''
+    """
 
 
 class Technician(dj.Manual):
-    definition = '''
+    definition = """
     technician_id: int auto_increment
     ---
     first_name : varchar(64)
     last_name : varchar(64)
     -> Investigator
-    '''
+    """
 
 
 class Publication(dj.Manual):
-    definition = '''
+    definition = """
     publication_id: int auto_increment
     ---
     name : varchar(512)
     kind : varchar(32)
     -> Investigator
-    '''
+    """
 
 
 class Report(dj.Manual):
-    definition = '''
+    definition = """
     report_id: int auto_increment
     ---
     title : varchar(512)
@@ -289,59 +290,59 @@ class Report(dj.Manual):
     
     last_name : varchar(64)
     -> Investigator
-    '''
+    """
 
 
 class Design(dj.Manual):
-    definition = '''
+    definition = """
     design_id: int auto_increment
     ---
     name : varchar(64)
-    '''
+    """
 
 
 class Block(dj.Manual):
-    definition = '''
+    definition = """
     block_id: int auto_increment
     ---
     -> Technician
     -> Design
-    '''
+    """
 
     class Trials(dj.Part):
-        definition = '''
+        definition = """
         -> Block
         -> Trial
         ---
-        '''
+        """
 
 
 class Experiment(dj.Manual):
-    definition = '''
+    definition = """
     experiment_id: int auto_increment
     ---
     -> Investigator
-    '''
+    """
 
     class Blocks(dj.Part):
-        definition = '''
+        definition = """
         -> Experiment
         -> Block
         ---
-        '''
+        """
 
 
 class Summary(dj.Manual):
-    definition = '''
+    definition = """
     summary_id: int auto_increment
     ---
     -> Publication
     -> Design
-    '''
+    """
 
     class Odorants(dj.Part):
-        definition = '''
+        definition = """
         -> Summary
         -> Odorant
         ---
-        '''
+        """

--- a/pyrfume/dbtables.py
+++ b/pyrfume/dbtables.py
@@ -1,12 +1,14 @@
 """ Definitions of datajoint tables and functions for operating the datajoint schema."""
 
-import datajoint as dj
-from datajoint.user_tables import UserTable
-import quantities as pq
-from pyrfume import read_config, write_config, init_config
 import inspect
 import warnings
 from typing import Dict
+
+import datajoint as dj
+import quantities as pq
+from datajoint.user_tables import UserTable
+
+from pyrfume import init_config, read_config, write_config
 
 dj.errors._switch_adapted_types(True)
 schema = None

--- a/pyrfume/dbtables.py
+++ b/pyrfume/dbtables.py
@@ -137,7 +137,7 @@ class Vendor(dj.Manual):
 
 class Product(dj.Manual):
     definition = """
-    -> Vendor 
+    -> Vendor
     catalog = 0 : int
     ---
     -> Molecule
@@ -289,7 +289,6 @@ class Report(dj.Manual):
     year : smallint
     -> Publication
     doi : varchar(128)
-    
     last_name : varchar(64)
     -> Investigator
     """

--- a/pyrfume/experiments.py
+++ b/pyrfume/experiments.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.stats import geom
 from typing import Any
 
+
 class TriangleTest(object):
     """
     One kind of experimental test, as performed by e.g. Bushdid et al.

--- a/pyrfume/experiments.py
+++ b/pyrfume/experiments.py
@@ -1,6 +1,7 @@
+from typing import Any
+
 import numpy as np
 from scipy.stats import geom
-from typing import Any
 
 
 class TriangleTest(object):

--- a/pyrfume/features.py
+++ b/pyrfume/features.py
@@ -8,14 +8,14 @@ from eden.graph import Vectorizer
 from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
 from tqdm.auto import tqdm, trange
 
-from pyrfume import load_data, logger, odorants, save_data
+from pyrfume import load_data, odorants, save_data
 from pyrfume.mol2networx import smiles_to_eden
 
 try:
     from mordred import Calculator
     from mordred import descriptors as all_descriptors
     from rdkit import Chem, DataStructs
-    from rdkit.Chem import AllChem, SaltRemover
+    from rdkit.Chem import AllChem
 except (ImportError, ModuleNotFoundError):
     warnings.warn(
         "Parts of mordred and/or rdkit could not be imported; try installing rdkit via conda",

--- a/pyrfume/features.py
+++ b/pyrfume/features.py
@@ -1,21 +1,21 @@
 import functools
-from typing import Iterable, Iterator, Optional, Callable
 import warnings
+from typing import Callable, Iterable, Iterator, Optional
 
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
-
 from eden.graph import Vectorizer
-from pyrfume import load_data, save_data, logger, odorants
-from pyrfume.mol2networx import smiles_to_eden
+from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
 from tqdm.auto import tqdm, trange
 
+from pyrfume import load_data, logger, odorants, save_data
+from pyrfume.mol2networx import smiles_to_eden
+
 try:
-    from mordred import Calculator, descriptors as all_descriptors
-    from rdkit import Chem
+    from mordred import Calculator
+    from mordred import descriptors as all_descriptors
+    from rdkit import Chem, DataStructs
     from rdkit.Chem import AllChem, SaltRemover
-    from rdkit import DataStructs
 except (ImportError, ModuleNotFoundError):
     warnings.warn(
         "Parts of mordred and/or rdkit could not be imported; try installing rdkit via conda",

--- a/pyrfume/haddad.py
+++ b/pyrfume/haddad.py
@@ -5,6 +5,7 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.preprocessing import StandardScaler
 
 import pyrfume
+
 from . import features
 from .base import DEFAULT_DATA_PATH
 

--- a/pyrfume/loaders/manoel_2016.py
+++ b/pyrfume/loaders/manoel_2016.py
@@ -21,5 +21,5 @@ def get_raw():
 
 
 def main():
-    translater = get_translater()
-    raw = get_raw()
+    get_translater()
+    get_raw()

--- a/pyrfume/loaders/manoel_2016.py
+++ b/pyrfume/loaders/manoel_2016.py
@@ -6,20 +6,19 @@ def get_translater():
     threeletter_to_pubchem = dict(rosetta.iloc[:, -1:-3:-1].values)
     threeletter_to_pubchem["MEN"] = threeletter_to_pubchem["+MEN"]
     return threeletter_to_pubchem
-    #pubchem_to_threeletter = {value: key for key, value in threeletter_to_pubchem.items()}
-    #pubchem_to_threeletter[1201521] = "+FCH"
-    #del pubchem_to_threeletter[16213045]
+    # pubchem_to_threeletter = {value: key for key, value in threeletter_to_pubchem.items()}
+    # pubchem_to_threeletter[1201521] = "+FCH"
+    # del pubchem_to_threeletter[16213045]
+
 
 def get_raw():
     # Load raw mouse data (individual mouse level)
-    raw = pd.read_csv(
-    "raw behavioral scores mouse 73 odorants.csv", index_col=0, header=1
-    ).dropna()
+    raw = pd.read_csv("raw behavioral scores mouse 73 odorants.csv", index_col=0, header=1).dropna()
     raw.index.name = "odor"
     raw = raw.sort_index()
     return raw
 
+
 def main():
     translater = get_translater()
     raw = get_raw()
-    

--- a/pyrfume/loaders/manoel_2016.py
+++ b/pyrfume/loaders/manoel_2016.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+
 # Load data about the odorants (names and PubChem IDs)
 def get_translater():
     rosetta = pd.read_excel("SmilesInfo2.xlsx")

--- a/pyrfume/objects.py
+++ b/pyrfume/objects.py
@@ -1,6 +1,7 @@
 import json
-import numpy as np
 import urllib
+
+import numpy as np
 
 
 class Mixture(object):

--- a/pyrfume/objects.py
+++ b/pyrfume/objects.py
@@ -9,7 +9,7 @@ class Mixture(object):
     candidate molecules in the mixture.
     """
 
-    def __init__(self, C: int, components: list=None):
+    def __init__(self, C: int, components: list = None):
         """
         Builds odorant from a list of components.
         """
@@ -20,7 +20,7 @@ class Mixture(object):
 
     C = None  # Number of components from which to choose.
 
-    def components_vector(self, all_components: list=None, normalize: float=0):
+    def components_vector(self, all_components: list = None, normalize: float = 0):
 
         vector = np.zeros(self.C)
         for component in self.components:
@@ -202,7 +202,9 @@ class Component(object):
     A single molecule, which may or may not be present in an odorant.
     """
 
-    def __init__(self, component_id: int, name: str, cas: str, percent: float, solvent: "Component"):
+    def __init__(
+        self, component_id: int, name: str, cas: str, percent: float, solvent: "Component"
+    ):
         """
         Components are defined by a component_id from the Bushdid et al
         supplemental material, a name, a CAS number, a percent dilution,

--- a/pyrfume/odorants.py
+++ b/pyrfume/odorants.py
@@ -8,7 +8,6 @@ import time
 import warnings
 from collections import OrderedDict
 from datetime import datetime
-from pathlib import Path
 from typing import Dict
 from urllib.parse import quote
 
@@ -21,7 +20,7 @@ from IPython.display import display
 from PIL import Image
 from quantities.constants.statisticalmechanics import R
 
-from pyrfume import load_data, logger, read_config, tqdm, trange
+from pyrfume import load_data, logger, tqdm, trange
 from pyrfume.physics import mackay
 
 try:
@@ -451,7 +450,7 @@ def get_cids(
     return results
 
 
-def get_cid(
+def get_cid(  # noqa: C901 (too complex -- TODO)
     identifier: str,
     kind: str = None,
     verbose: bool = True,
@@ -666,7 +665,6 @@ def _parse_other_info(info, records=None):
 
 def display_molecules(molecules: pd.DataFrame, no_of_columns=5, figsize=(15, 15)):
     import matplotlib.pyplot as plt
-    from IPython.display import display
 
     fig = plt.figure(figsize=figsize)
     column = 0
@@ -722,7 +720,7 @@ def smiles_to_mol(
     if deisomerize:
         f = deisomerize_smiles
     else:
-        f = lambda x: x
+        f = lambda x: x  # noqa: E731 (don't assign lambda -- TODO)
     mols_raw = [Chem.MolFromSmiles(f(smi)) for smi in smiles]
     logger.info("Computing 3D coordinates...")
     s = SaltRemover.SaltRemover()

--- a/pyrfume/odorants.py
+++ b/pyrfume/odorants.py
@@ -19,8 +19,9 @@ import requests
 from IPython.display import display
 from PIL import Image
 from quantities.constants.statisticalmechanics import R
+from tqdm.auto import tqdm, trange
 
-from pyrfume import load_data, logger, tqdm, trange
+from pyrfume import load_data, logger
 from pyrfume.physics import mackay
 
 try:

--- a/pyrfume/odorants.py
+++ b/pyrfume/odorants.py
@@ -8,27 +8,25 @@ import time
 import warnings
 from collections import OrderedDict
 from datetime import datetime
-from urllib.parse import quote
 from pathlib import Path
+from typing import Dict
+from urllib.parse import quote
 
-from datetime import datetime
 import numpy as np
 import pandas as pd
 import pubchempy as pcp
+import quantities as pq
 import requests
 from IPython.display import display
 from PIL import Image
-
-import quantities as pq
-from pyrfume import load_data, logger, tqdm, trange, read_config
-from pyrfume.physics import mackay
 from quantities.constants.statisticalmechanics import R
-from typing import Dict
+
+from pyrfume import load_data, logger, read_config, tqdm, trange
+from pyrfume.physics import mackay
 
 try:
-    from rdkit import Chem
-    from rdkit.Chem import Draw, AllChem, SaltRemover
-    from rdkit import RDLogger
+    from rdkit import Chem, RDLogger
+    from rdkit.Chem import AllChem, Draw, SaltRemover
 
     rdkit_logger = RDLogger.logger()
     RDKIT = True

--- a/pyrfume/optimization.py
+++ b/pyrfume/optimization.py
@@ -87,9 +87,9 @@ class OdorantSetOptimizer:
 
         # Describe the process for selecting a random set of items
         if self.keep is not None:
-            f_keep = lambda explore, needed: self.keep_ix | set(
+            f_keep = lambda explore, needed: self.keep_ix | set(  # noqa: E731 (TODO)
                 random.sample(explore, needed)
-            )  # noqa: E731 (TODO)
+            )
             self.toolbox.register("random_set", f_keep, self.explore_ix, self.n_needed)
         else:
             self.toolbox.register(

--- a/pyrfume/optimization.py
+++ b/pyrfume/optimization.py
@@ -78,7 +78,7 @@ class OdorantSetOptimizer:
             # Get library integer indices of the CIDs to keep
             is_kept = self.library.index.isin(self.keep)
             self.keep_ix = set(np.flatnonzero(is_kept))
-            self.explore_ix = set(np.flatnonzero(1-is_kept))
+            self.explore_ix = set(np.flatnonzero(1 - is_kept))
             self.n_needed = self.n_desired - len(self.keep_ix)
 
         # Setup DEAP fundamentals
@@ -91,8 +91,10 @@ class OdorantSetOptimizer:
             f_keep = lambda explore, needed: self.keep_ix | set(random.sample(explore, needed))
             self.toolbox.register("random_set", f_keep, self.explore_ix, self.n_needed)
         else:
-            self.toolbox.register("random_set", random.sample, range(self.library_size), self.n_desired)
-        
+            self.toolbox.register(
+                "random_set", random.sample, range(self.library_size), self.n_desired
+            )
+
         # Describe the process for creating a single set
         self.toolbox.register(
             "individual", tools.initIterate, creator.Individual, self.toolbox.random_set
@@ -138,8 +140,8 @@ class OdorantSetOptimizer:
         Returns:
             A fitness score.
         """
-        
-        #print(len(ind - self.keep_ix))
+
+        # print(len(ind - self.keep_ix))
         fitness = []
         for weight_name, func_name, value in self.weights:
             if isinstance(func_name, str):
@@ -253,7 +255,7 @@ class OdorantSetOptimizer:
         self.stats.register("best", best)
 
         f = algorithms.eaMuPlusLambda
-        #with suppress_stdout(quiet):
+        # with suppress_stdout(quiet):
         self.pop, self.logbook = f(
             self.pop,
             self.toolbox,
@@ -323,40 +325,39 @@ class OdorantSetOptimizer:
             ax.set_title(feature)
         axes[0, 0].set_xlabel("Generation")
         plt.tight_layout()
-        
+
     def summarize_gene(self, gene=None, n_cols=4):
-        gene = gene or self.hof[0] 
+        gene = gene or self.hof[0]
         assert gene
         attributes = self.library.iloc[list(gene)]
         n_attributes = attributes.shape[1]
-        n_rows = math.ceil(n_attributes/n_cols)
+        n_rows = math.ceil(n_attributes / n_cols)
         n_cols = min(n_attributes, n_cols)
-        fig, axes = plt.subplots(n_rows, n_cols, figsize=(n_cols*2, n_rows*2))
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(n_cols * 2, n_rows * 2))
         for col, ax in zip(attributes, axes.flat):
             counts = attributes[col].value_counts().sort_index()
-            if len(counts)<=2:
+            if len(counts) <= 2:
                 counts.plot.bar(ax=ax)
             else:
                 attributes[col].hist(ax=ax)
             ax.set_title(col)
         plt.tight_layout()
-        
+
     def embed_gene_2d(self, emb, gene=None, size_col=None, size=(0, 5)):
         """
         size: a tuple of base size and a multiplier for values in the size column
         """
-        gene = gene or self.hof[0] 
+        gene = gene or self.hof[0]
         assert gene
         x, y = emb.columns[:2]
         if size_col is None:
             size_series = pd.Series(1, index=self.library.index)
         else:
             size_series = self.library[size_col]
-        size_series = size[0] + size[1]*size_series.copy()
+        size_series = size[0] + size[1] * size_series.copy()
         ix = list(gene)
         ax = emb.plot.scatter(x=x, y=y, s=size_series, alpha=0.5)
-        emb.iloc[ix].plot.scatter(x=x, y=y, s=size_series.iloc[ix],
-                                  alpha=0.5, color='r', ax=ax)
+        emb.iloc[ix].plot.scatter(x=x, y=y, s=size_series.iloc[ix], alpha=0.5, color="r", ax=ax)
 
 
 class BetterFitness(base.Fitness):

--- a/pyrfume/optimization.py
+++ b/pyrfume/optimization.py
@@ -87,7 +87,7 @@ class OdorantSetOptimizer:
 
         # Describe the process for selecting a random set of items
         if self.keep is not None:
-            f_keep = lambda explore, needed: self.keep_ix | set(random.sample(explore, needed))
+            f_keep = lambda explore, needed: self.keep_ix | set(random.sample(explore, needed))  # noqa: E731 (don't assign lambda -- TODO)
             self.toolbox.register("random_set", f_keep, self.explore_ix, self.n_needed)
         else:
             self.toolbox.register(

--- a/pyrfume/optimization.py
+++ b/pyrfume/optimization.py
@@ -87,7 +87,9 @@ class OdorantSetOptimizer:
 
         # Describe the process for selecting a random set of items
         if self.keep is not None:
-            f_keep = lambda explore, needed: self.keep_ix | set(random.sample(explore, needed))  # noqa: E731 (don't assign lambda -- TODO)
+            f_keep = lambda explore, needed: self.keep_ix | set(
+                random.sample(explore, needed)
+            )  # noqa: E731 (TODO)
             self.toolbox.register("random_set", f_keep, self.explore_ix, self.n_needed)
         else:
             self.toolbox.register(

--- a/pyrfume/optimization.py
+++ b/pyrfume/optimization.py
@@ -4,11 +4,10 @@ import math
 import random
 import sys
 
+import dask.bag as db
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
-import dask.bag as db
 from deap import algorithms, base, creator, tools
 
 

--- a/pyrfume/physics.py
+++ b/pyrfume/physics.py
@@ -23,7 +23,7 @@ def mackay(vp):
     else:
         er = 0
     # Attach units
-    er *= pq.mol / (pq.m ** 2 * pq.s)
+    er *= pq.mol / (pq.m**2 * pq.s)
     return er
 
 
@@ -42,20 +42,20 @@ def bernoulli(v=None, p=None, rho=None, g=9.8 * pq.m / (pq.s) ** 2, z=0, k=None)
     if rho is None:
         rho = Symbol("rho", real=True, positive=True)
     else:
-        rho = rho.rescale(pq.kg / (pq.m ** 3))
+        rho = rho.rescale(pq.kg / (pq.m**3))
         rho = float(rho.simplified)
     if k is None:
         k = Symbol("k", real=True, positive=True)
     else:
         k = k.rescale((pq.m / pq.s) ** 2)
         k = float(k.simplified)
-    result = solve((v ** 2) / 2 + g * z + p / rho - k, [v, p, rho], dict=True)
+    result = solve((v**2) / 2 + g * z + p / rho - k, [v, p, rho], dict=True)
     return result
 
 
 def venturi(rho=None, p1=None, p2=None, v1=None, v2=None):
     assert rho is not None
-    rho = rho.rescale(pq.kg / (pq.m ** 3))
+    rho = rho.rescale(pq.kg / (pq.m**3))
     rho = float(rho.simplified)
 
     if v1 is None:
@@ -79,12 +79,12 @@ def venturi(rho=None, p1=None, p2=None, v1=None, v2=None):
         p2 = p2.rescale(pq.Pa)
         p2 = float(p2.simplified)
 
-    result = solve(rho * (v2 ** 2 - v1 ** 2) / 2 - p1 + p2, [v1, v2, p1, p2], dict=True)
+    result = solve(rho * (v2**2 - v1**2) / 2 - p1 + p2, [v1, v2, p1, p2], dict=True)
     return result
 
 
 if __name__ == "__main__":
     # print(bernoulli(None, 10*pq.psi, 1.225*pq.kg/(pq.m**3)))
     print(
-        venturi(rho=1.225 * pq.kg / (pq.m ** 3), p1=10 * pq.psi, p2=1 * pq.psi, v1=10 * pq.m / pq.s)
+        venturi(rho=1.225 * pq.kg / (pq.m**3), p1=10 * pq.psi, p2=1 * pq.psi, v1=10 * pq.m / pq.s)
     )

--- a/pyrfume/plotting.py
+++ b/pyrfume/plotting.py
@@ -6,12 +6,11 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objs as go
 from ipywidgets import Image, Layout, VBox
+from rdkit import Chem
+from rdkit.Chem import Draw
 
 import pyrfume
 from pyrfume.odorants import smiles_to_image
-
-from rdkit import Chem
-from rdkit.Chem import Draw
 
 
 def mpl_embedding(

--- a/pyrfume/plotting.py
+++ b/pyrfume/plotting.py
@@ -1,13 +1,7 @@
-import io
-import warnings
 
 import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
 import plotly.graph_objs as go
 from ipywidgets import Image, Layout, VBox
-from rdkit import Chem
-from rdkit.Chem import Draw
 
 import pyrfume
 from pyrfume.odorants import smiles_to_image

--- a/pyrfume/plotting.py
+++ b/pyrfume/plotting.py
@@ -43,7 +43,9 @@ def mpl_embedding(
         ax.set_title(title)
 
 
-def plotly_embedding(embedding, features=None, show_features=None, colors=None, colorscale='rainbow'):
+def plotly_embedding(
+    embedding, features=None, show_features=None, colors=None, colorscale="rainbow"
+):
     """
     params:
         embedding: A dataframe wrapped around e.g. a fitted TSNE object, with an index of CIDs
@@ -56,10 +58,12 @@ def plotly_embedding(embedding, features=None, show_features=None, colors=None, 
         # Only retain those rows corresponding to odorants in the embedding
     features = features.loc[embedding.index]
     show_features = show_features or list(features)
+
     def format_features(col):
-        return "%s: %s" % (index_name, col.values.split('<br>'))
+        return "%s: %s" % (index_name, col.values.split("<br>"))
+
     try:
-        index_name = features.index.name or 'Index'
+        index_name = features.index.name or "Index"
         names = (
             features.loc[:, show_features]
             .reset_index()
@@ -85,7 +89,7 @@ def plotly_embedding(embedding, features=None, show_features=None, colors=None, 
             "colorscale": colorscale,
         },
     )
-    
+
     # The axes, etc.
     layout = go.Layout(
         xaxis={"type": "linear", "title": "", "showline": False, "showticklabels": False},
@@ -100,7 +104,7 @@ def plotly_embedding(embedding, features=None, show_features=None, colors=None, 
     )
 
     fig = go.FigureWidget(data=[scatter], layout=layout)
-    fig.layout.hovermode = 'closest'
+    fig.layout.hovermode = "closest"
 
     # The 2D drawing of the molecule
     image_widget = Image(

--- a/pyrfume/plotting.py
+++ b/pyrfume/plotting.py
@@ -1,4 +1,3 @@
-
 import matplotlib.pyplot as plt
 import plotly.graph_objs as go
 from ipywidgets import Image, Layout, VBox

--- a/pyrfume/pubchem.py
+++ b/pyrfume/pubchem.py
@@ -27,8 +27,7 @@ def parse_summary_for_odor(summary):
 def get_physical_description(cid):
     url = (
         "https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/data/compound/%d/JSON?heading="
-        "Physical+Description"
-        % cid
+        "Physical+Description" % cid
     )
     result = requests.get(url)
     try:
@@ -63,8 +62,7 @@ def parse_physical_description_for_odor(physical_description):
 def get_ghs_classification(cid):
     url = (
         "https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/data/compound/%d/JSON?heading=GHS"
-        "+Classification"
-        % cid
+        "+Classification" % cid
     )
     result = requests.get(url)
     try:
@@ -140,17 +138,18 @@ def parse_ghs_classification_for_odor(
 
 def get_strings(annotation):
     strings = []
-    for x in annotation['Data']:
-        for y in x['Value']['StringWithMarkup']:
-            strings.append(y['String'])
+    for x in annotation["Data"]:
+        for y in x["Value"]["StringWithMarkup"]:
+            strings.append(y["String"])
     return strings
+
 
 def update_results(records, results):
     # Iterate through the list of annotations
-    for annotation in tqdm(records['Annotations']['Annotation']):
+    for annotation in tqdm(records["Annotations"]["Annotation"]):
         try:
             # Get CIDs for the current record
-            cids = annotation['LinkedRecords']['CID']
+            cids = annotation["LinkedRecords"]["CID"]
         except:
             # If they are none then just move to the next annoation
             pass
@@ -158,15 +157,17 @@ def update_results(records, results):
             # If there are CIDs then extract the corresponding record content
             # Iterate through the actual text of the data
             strings = get_strings(annotation)
-            
+
             # Associate with each of the associated CIDs
             for cid in cids:
                 results[cid] = (results.get(cid) or []) + strings
 
 
 def get_records(heading, page):
-    url = (f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
-           f"JSON?heading_type=Compound&heading={heading}&page={page}")
+    url = (
+        f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/heading/"
+        f"JSON?heading_type=Compound&heading={heading}&page={page}"
+    )
     response = requests.get(url)
     records = response.json()
     return records
@@ -180,10 +181,10 @@ def get_results(heading):
     # Update results with the parsed output of the first page
     update_results(page_1_records, results)
     # Check how many total pages the response has
-    n_pages = page_1_records['Annotations']['TotalPages']
-    
+    n_pages = page_1_records["Annotations"]["TotalPages"]
+
     # Iterate through the remaining pages, if any
-    p_bar = trange(2, n_pages+1)
+    p_bar = trange(2, n_pages + 1)
     for page in p_bar:
         page_n_records = get_records(heading, page)
         update_results(page_n_records, results)

--- a/pyrfume/pubchem.py
+++ b/pyrfume/pubchem.py
@@ -150,7 +150,7 @@ def update_results(records, results):
         try:
             # Get CIDs for the current record
             cids = annotation["LinkedRecords"]["CID"]
-        except:
+        except Exception:
             # If they are none then just move to the next annoation
             pass
         else:

--- a/pyrfume/sigma_ff.py
+++ b/pyrfume/sigma_ff.py
@@ -10,7 +10,7 @@ import pyrfume
 CATALOG_PATH = pyrfume.DEFAULT_DATA_PATH / "sigma" / "sigma_ff_catalog.txt"
 
 
-def get_data():
+def get_data():  # noqa: C901 (too complex -- TODO)
     with open(CATALOG_PATH, "r") as f:
         text = f.read()
         lines = text.split("\n")

--- a/pyrfume/unit_test/__main__.py
+++ b/pyrfume/unit_test/__main__.py
@@ -12,15 +12,17 @@ from .test_physics import *
 from .test_odorants import *
 from .test_datajoint_tools import DataJointTestCase
 
+
 def main():
-    buffer = 'buffer' in sys.argv
-    database = 'database' in sys.argv
+    buffer = "buffer" in sys.argv
+    database = "database" in sys.argv
     sys.argv = sys.argv[:1]
 
     if not database:
-        globals().pop('DataJointTestCase')
+        globals().pop("DataJointTestCase")
 
     unittest.main(buffer=buffer)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/pyrfume/unit_test/__main__.py
+++ b/pyrfume/unit_test/__main__.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 from .test_config_data import *
+from .test_datajoint_tools import DataJointTestCase
 from .test_docs import *
 from .test_load_data import *
 from .test_make_solutions import *

--- a/pyrfume/unit_test/__main__.py
+++ b/pyrfume/unit_test/__main__.py
@@ -1,16 +1,16 @@
 import sys
 import unittest
 
+from .test_config_data import *
+from .test_datajoint_tools import DataJointTestCase
 from .test_docs import *
 from .test_load_data import *
-from .test_config_data import *
 from .test_make_solutions import *
 from .test_mixture import *
-from .test_test import *
+from .test_odorants import *
 from .test_others_in__init__ import *
 from .test_physics import *
-from .test_odorants import *
-from .test_datajoint_tools import DataJointTestCase
+from .test_test import *
 
 
 def main():

--- a/pyrfume/unit_test/__main__.py
+++ b/pyrfume/unit_test/__main__.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 
 from .test_config_data import *
-from .test_datajoint_tools import DataJointTestCase
 from .test_docs import *
 from .test_load_data import *
 from .test_make_solutions import *

--- a/pyrfume/unit_test/test_config_data.py
+++ b/pyrfume/unit_test/test_config_data.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 
 class DataAndConfigTestCase(unittest.TestCase):
@@ -17,9 +17,10 @@ class DataAndConfigTestCase(unittest.TestCase):
         self.assertEqual(read_config("PATHS", "a"), "b")
 
     def test_data_path(self):
-        from pyrfume import set_data_path, get_data_path
-        from pyrfume.base import PACKAGE_DIR, DEFAULT_DATA_PATH
         import os
+
+        from pyrfume import get_data_path, set_data_path
+        from pyrfume.base import DEFAULT_DATA_PATH, PACKAGE_DIR
 
         curr_data_path = get_data_path()
 
@@ -40,10 +41,13 @@ class DataAndConfigTestCase(unittest.TestCase):
         set_data_path(curr_data_path)
 
     def test_load_data(self):
-        import pickle, os
-        from pyrfume.base import DEFAULT_DATA_PATH
-        from pyrfume import load_data, save_data
+        import os
+        import pickle
+
         import pandas as pd
+
+        from pyrfume import load_data, save_data
+        from pyrfume.base import DEFAULT_DATA_PATH
 
         data = {"col1": [1, 2], "col2": [3, 4]}
         file_path = DEFAULT_DATA_PATH / "data.pkl"

--- a/pyrfume/unit_test/test_config_data.py
+++ b/pyrfume/unit_test/test_config_data.py
@@ -73,7 +73,9 @@ class DataAndConfigTestCase(unittest.TestCase):
         os.remove(file_path)
 
     def test_save_data(self):
-        from pyrfume.base import DEFAULT_DATA_PATH  # noqa: F401 (not sure what this is for? -- TODO)
+        from pyrfume.base import (  # noqa: F401 (not sure what this is for? -- TODO)
+            DEFAULT_DATA_PATH,
+        )
 
 
 if __name__ == "__main__":

--- a/pyrfume/unit_test/test_config_data.py
+++ b/pyrfume/unit_test/test_config_data.py
@@ -1,16 +1,18 @@
 from pathlib import Path
 import unittest
 
-class DataAndConfigTestCase(unittest.TestCase):
 
+class DataAndConfigTestCase(unittest.TestCase):
     def test_init_reset_config(self):
         from pyrfume import init_config, reset_config
+
         init_config(False)
         reset_config()
         init_config(True)
-        
+
     def test_read_write_config(self):
         from pyrfume import read_config, write_config
+
         write_config("PATHS", "a", "b")
         self.assertEqual(read_config("PATHS", "a"), "b")
 
@@ -20,7 +22,7 @@ class DataAndConfigTestCase(unittest.TestCase):
         import os
 
         curr_data_path = get_data_path()
-        
+
         path_not_exists = PACKAGE_DIR / "THIS_IS_AN_INVALID_PATH"
         self.assertRaises(Exception, set_data_path, path_not_exists, create=False)
         self.assertRaises(Exception, get_data_path, path_not_exists, create=False)
@@ -43,10 +45,10 @@ class DataAndConfigTestCase(unittest.TestCase):
         from pyrfume import load_data, save_data
         import pandas as pd
 
-        data = {'col1': [1, 2], 'col2': [3, 4]}
+        data = {"col1": [1, 2], "col2": [3, 4]}
         file_path = DEFAULT_DATA_PATH / "data.pkl"
         path_not_exists = DEFAULT_DATA_PATH / "THIS_IS_AN_INVALID_PATH"
-        
+
         self.assertRaises(Exception, save_data, data, path_not_exists)
         save_data(data, file_path)
 
@@ -58,7 +60,7 @@ class DataAndConfigTestCase(unittest.TestCase):
 
         df = pd.DataFrame(data)
         save_data(df, file_path)
-        #with open(file_path, "w") as f:
+        # with open(file_path, "w") as f:
         #    f.write("0,1,2,3\n0,1,2,3")
 
         data_gain = load_data(file_path)
@@ -66,12 +68,12 @@ class DataAndConfigTestCase(unittest.TestCase):
         for index1 in range(len(data_gain.values)):
             for index2 in range(len(data_gain.values[index1])):
                 self.assertEqual(data_gain.values[index1][index2], df.values[index1][index2])
-                
+
         os.remove(file_path)
 
     def test_save_data(self):
         from pyrfume.base import DEFAULT_DATA_PATH
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_config_data.py
+++ b/pyrfume/unit_test/test_config_data.py
@@ -17,8 +17,6 @@ class DataAndConfigTestCase(unittest.TestCase):
         self.assertEqual(read_config("PATHS", "a"), "b")
 
     def test_data_path(self):
-        import os
-
         from pyrfume import get_data_path, set_data_path
         from pyrfume.base import DEFAULT_DATA_PATH, PACKAGE_DIR
 
@@ -42,7 +40,6 @@ class DataAndConfigTestCase(unittest.TestCase):
 
     def test_load_data(self):
         import os
-        import pickle
 
         import pandas as pd
 
@@ -76,7 +73,7 @@ class DataAndConfigTestCase(unittest.TestCase):
         os.remove(file_path)
 
     def test_save_data(self):
-        from pyrfume.base import DEFAULT_DATA_PATH
+        from pyrfume.base import DEFAULT_DATA_PATH  # noqa: F401 (not sure what this is for? -- TODO)
 
 
 if __name__ == "__main__":

--- a/pyrfume/unit_test/test_datajoint_tools.py
+++ b/pyrfume/unit_test/test_datajoint_tools.py
@@ -3,17 +3,15 @@ import datajoint as dj
 import pandas as pd
 
 
-
 class DataJointTestCase(unittest.TestCase):
-
     def setUp(self):
-        dj.config['database.host'] = '127.0.0.1'
-        dj.config['database.user'] = 'root'
-        dj.config['database.password'] = 'simple'
+        dj.config["database.host"] = "127.0.0.1"
+        dj.config["database.user"] = "root"
+        dj.config["database.password"] = "simple"
 
     def test_schematizing_odorants(self):
-        """Test case for schematizations of classes in the odorants module 
-            and inserting sample data into datajoint table.
+        """Test case for schematizations of classes in the odorants module
+        and inserting sample data into datajoint table.
         """
 
         from pyrfume.odorants import Molecule, Vendor, ChemicalOrder, Compound, Solution
@@ -24,7 +22,7 @@ class DataJointTestCase(unittest.TestCase):
         schema.drop(force=True)
         schema = dj.schema("test_schema", schematized_classes)
 
-        classes_tobe_schematized = ['Molecule', 'Vendor', 'ChemicalOrder', 'Compound', 'Solution']
+        classes_tobe_schematized = ["Molecule", "Vendor", "ChemicalOrder", "Compound", "Solution"]
         for cls_name in classes_tobe_schematized:
             schematized_classes[cls_name] = djt.schematize(locals()[cls_name], schema)
 
@@ -32,29 +30,38 @@ class DataJointTestCase(unittest.TestCase):
         for cls_name in classes_tobe_schematized:
             self.assertIsInstance(schematized_classes[cls_name].definition, str)
 
-
-        Molecule = schematized_classes['Molecule']
-        Molecule.insert1({'cid': 6334, 'cas': '', 'name': 'propane', 'iupac': 'propane', 'synonyms': ''})
+        Molecule = schematized_classes["Molecule"]
+        Molecule.insert1(
+            {"cid": 6334, "cas": "", "name": "propane", "iupac": "propane", "synonyms": ""}
+        )
         molecules = pd.DataFrame(Molecule.fetch())
         self.assertEqual(molecules.shape[0], 1)
 
-        Vendor = schematized_classes['Vendor']
+        Vendor = schematized_classes["Vendor"]
         Vendor.insert1({"name": "vendor1", "url": "www.vendor1.com"})
         vendors = pd.DataFrame(Vendor.fetch())
         self.assertEqual(vendors.shape[0], 1)
 
-        ChemicalOrder = schematized_classes['ChemicalOrder']
-        ChemicalOrder.insert1({"molecule_id": 1, "vendor_id": 1, 'part_id': 1, 'purity': 0.5})
+        ChemicalOrder = schematized_classes["ChemicalOrder"]
+        ChemicalOrder.insert1({"molecule_id": 1, "vendor_id": 1, "part_id": 1, "purity": 0.5})
         chemicalorders = pd.DataFrame(ChemicalOrder.fetch())
         self.assertEqual(chemicalorders.shape[0], 1)
 
-        Compound = schematized_classes['Compound']
-        Compound.insert1({'chemicalorder_id': 1, 'stock': 'enough', 'is_solvent': 1, 'date_arrived': '2020-09-27 02:18:24', 'date_opened': '2020-09-27 02:18:24'})
+        Compound = schematized_classes["Compound"]
+        Compound.insert1(
+            {
+                "chemicalorder_id": 1,
+                "stock": "enough",
+                "is_solvent": 1,
+                "date_arrived": "2020-09-27 02:18:24",
+                "date_opened": "2020-09-27 02:18:24",
+            }
+        )
         compounds = pd.DataFrame(Compound.fetch())
         self.assertEqual(compounds.shape[0], 1)
 
-        Solution = schematized_classes['Solution']
-        Solution.insert1({"date_created": '2020-09-27 02:18:24'})
+        Solution = schematized_classes["Solution"]
+        Solution.insert1({"date_created": "2020-09-27 02:18:24"})
         solutions = pd.DataFrame(Solution.fetch())
         self.assertEqual(solutions.shape[0], 1)
 
@@ -63,5 +70,5 @@ class DataJointTestCase(unittest.TestCase):
         self.assertEqual(solution_components.shape[0], 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_datajoint_tools.py
+++ b/pyrfume/unit_test/test_datajoint_tools.py
@@ -1,4 +1,5 @@
 import unittest
+
 import datajoint as dj
 import pandas as pd
 
@@ -14,8 +15,8 @@ class DataJointTestCase(unittest.TestCase):
         and inserting sample data into datajoint table.
         """
 
-        from pyrfume.odorants import Molecule, Vendor, ChemicalOrder, Compound, Solution
         from pyrfume import datajoint_tools as djt
+        from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Solution, Vendor
 
         schematized_classes = {}
         schema = dj.schema("test_schema")

--- a/pyrfume/unit_test/test_docs.py
+++ b/pyrfume/unit_test/test_docs.py
@@ -8,32 +8,33 @@ import unittest
 class DocsTest(unittest.TestCase):
     def setUp(self):
         import pyrfume
+
         pyrfume_dir = Path(pyrfume.__path__[0]).parent
-        self.docs_path = pyrfume_dir / 'docs'
-        #pyrfume.set_data_path(pyrfume_dir.parent / 'pyrfume-data')
-    
+        self.docs_path = pyrfume_dir / "docs"
+        # pyrfume.set_data_path(pyrfume_dir.parent / 'pyrfume-data')
+
     def execute(self, path):
         with open(path) as f:
             nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
         ep.preprocess(nb)
-        
+
     def execute_doc(self, name):
-        self.execute(self.docs_path / (name+'.ipynb'))
+        self.execute(self.docs_path / (name + ".ipynb"))
 
     def test_1_your_data(self):
-        self.execute_doc('your-data')
-        
-    @unittest.skipIf('spike' not in platform.node(), "Only tested on Spike")
+        self.execute_doc("your-data")
+
+    @unittest.skipIf("spike" not in platform.node(), "Only tested on Spike")
     def test_2_featurization(self):
-        self.execute_doc('featurization')
-        
+        self.execute_doc("featurization")
+
     def test_3_visualization(self):
-        self.execute_doc('visualization')
-        
+        self.execute_doc("visualization")
+
     def test_4_published_data(self):
-        self.execute_doc('published-data')
+        self.execute_doc("published-data")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_docs.py
+++ b/pyrfume/unit_test/test_docs.py
@@ -1,8 +1,9 @@
-from nbconvert.preprocessors import ExecutePreprocessor
-import nbformat
-from pathlib import Path
 import platform
 import unittest
+from pathlib import Path
+
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
 
 
 class DocsTest(unittest.TestCase):

--- a/pyrfume/unit_test/test_features.py
+++ b/pyrfume/unit_test/test_features.py
@@ -7,10 +7,10 @@ from pyrfume.features import tanimoto_sim, get_maximum_tanimoto_similarity
 class TanimotoTestCase(unittest.TestCase):
     def setUp(self):
         self.n = 100
-        smiles = all_smiles()[:self.n]  # First 100 smiles
+        smiles = all_smiles()[: self.n]  # First 100 smiles
         mols = smiles_to_mol(smiles)
         self.mols = list(mols.values())
-        
+
     def test_tanimoto_sim(self):
         sim = tanimoto_sim(self.mols[0], self.mols[1])
         self.assertIsInstance(sim, float)
@@ -19,7 +19,7 @@ class TanimotoTestCase(unittest.TestCase):
 
     def test_bulk_tanimoto(self):
         # First 50 vs last 50
-        m = int(self.n/2)
+        m = int(self.n / 2)
         sims = get_maximum_tanimoto_similarity(self.mols[:m], self.mols[m:])
         self.assertIsInstance(sims, np.ndarray)
         self.assertEqual(len(sims), m)
@@ -27,5 +27,5 @@ class TanimotoTestCase(unittest.TestCase):
         self.assertLess(sims.max(), 1.0)  # None should be maximally self-similar
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_features.py
+++ b/pyrfume/unit_test/test_features.py
@@ -1,7 +1,9 @@
 import unittest
+
 import numpy as np
+
+from pyrfume.features import get_maximum_tanimoto_similarity, tanimoto_sim
 from pyrfume.odorants import all_smiles, smiles_to_mol
-from pyrfume.features import tanimoto_sim, get_maximum_tanimoto_similarity
 
 
 class TanimotoTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_load_data.py
+++ b/pyrfume/unit_test/test_load_data.py
@@ -6,21 +6,22 @@ import pyrfume
 
 class DataLoadRemoteTestCase(unittest.TestCase):
     def test_load_manoel_2021(self):
-        data = pyrfume.load_data('manoel_2021/behavior.csv')
-    
+        data = pyrfume.load_data("manoel_2021/behavior.csv")
+
     def test_load_snitz_2013(self):
-        data = pyrfume.load_data('snitz_2013/behavior.csv')
-        molecules = pyrfume.load_data('snitz_2013/molecules.csv')
-        
+        data = pyrfume.load_data("snitz_2013/behavior.csv")
+        molecules = pyrfume.load_data("snitz_2013/molecules.csv")
+
     def test_load_ravia_2020(self):
-        data = pyrfume.load_data('ravia_2020/behavior1.csv')
-        manifest = pyrfume.load_manifest('ravia_2020')
-        
-    @unittest.skipIf('spike' not in platform.node(), "Only tested on Spike")
+        data = pyrfume.load_data("ravia_2020/behavior1.csv")
+        manifest = pyrfume.load_manifest("ravia_2020")
+
+    @unittest.skipIf("spike" not in platform.node(), "Only tested on Spike")
     def test_load_morgan_skipped(self):
         my_cids = [129, 239]
-        morgan_sim = pyrfume.load_data('morgan/features_sim.csv', cids=my_cids)
+        morgan_sim = pyrfume.load_data("morgan/features_sim.csv", cids=my_cids)
         self.assertEqual(morgan_sim.shape[0], len(my_cids))
-        
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_load_data.py
+++ b/pyrfume/unit_test/test_load_data.py
@@ -6,15 +6,15 @@ import pyrfume
 
 class DataLoadRemoteTestCase(unittest.TestCase):
     def test_load_manoel_2021(self):
-        data = pyrfume.load_data("manoel_2021/behavior.csv")
+        pyrfume.load_data("manoel_2021/behavior.csv")
 
     def test_load_snitz_2013(self):
-        data = pyrfume.load_data("snitz_2013/behavior.csv")
-        molecules = pyrfume.load_data("snitz_2013/molecules.csv")
+        pyrfume.load_data("snitz_2013/behavior.csv")
+        pyrfume.load_data("snitz_2013/molecules.csv")
 
     def test_load_ravia_2020(self):
-        data = pyrfume.load_data("ravia_2020/behavior1.csv")
-        manifest = pyrfume.load_manifest("ravia_2020")
+        pyrfume.load_data("ravia_2020/behavior1.csv")
+        pyrfume.load_manifest("ravia_2020")
 
     @unittest.skipIf("spike" not in platform.node(), "Only tested on Spike")
     def test_load_morgan_skipped(self):

--- a/pyrfume/unit_test/test_make_solutions.py
+++ b/pyrfume/unit_test/test_make_solutions.py
@@ -1,7 +1,7 @@
-from pyrfume.odorants import Solution, Compound, ChemicalOrder, \
-                                  Vendor, Molecule
+from pyrfume.odorants import Solution, Compound, ChemicalOrder, Vendor, Molecule
 import quantities as pq
 import unittest
+
 
 class MakeSolutionTestCase(unittest.TestCase):
     def test_make_solution(self):
@@ -13,42 +13,38 @@ class MakeSolutionTestCase(unittest.TestCase):
         light_mineral_oil = Molecule(347911206, fill=True)  # An odorless solvent
 
         # Vapor pressures at 25 degrees Celsius (obtained from PubChem)
-        beta_pinene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
-        d_limonene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
-        l_limonene.vapor_pressure = 10 * pq.mmHg # Made up, fill with real values
+        beta_pinene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
+        d_limonene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
+        l_limonene.vapor_pressure = 10 * pq.mmHg  # Made up, fill with real values
         light_mineral_oil.vapor_pressure = 0 * pq.mmHg  # Actually .0001 * pq.hPa
 
         # Densities at 20 degrees Celsius (obtained from PubChem)
-        beta_pinene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-        d_limonene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-        l_limonene.density = 1.0 * pq.g/pq.cc # Made up, fill with real values
-        light_mineral_oil.density = 0.85 * pq.g/pq.cc # Made up, fill with real values
+        beta_pinene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+        d_limonene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+        l_limonene.density = 1.0 * pq.g / pq.cc  # Made up, fill with real values
+        light_mineral_oil.density = 0.85 * pq.g / pq.cc  # Made up, fill with real values
 
         light_mineral_oil.molecular_weight = 500 * pq.g / pq.mol
 
-        sigma_aldrich = Vendor('Sigma Aldrich', 'http://www.sigma.com')
+        sigma_aldrich = Vendor("Sigma Aldrich", "http://www.sigma.com")
 
-        solvent_order = ChemicalOrder(light_mineral_oil, sigma_aldrich, '')
+        solvent_order = ChemicalOrder(light_mineral_oil, sigma_aldrich, "")
 
-        chemical_orders = [ChemicalOrder(beta_pinene, sigma_aldrich, ''),
-                        ChemicalOrder(d_limonene, sigma_aldrich, ''),
-                        ChemicalOrder(l_limonene, sigma_aldrich, '')]
+        chemical_orders = [
+            ChemicalOrder(beta_pinene, sigma_aldrich, ""),
+            ChemicalOrder(d_limonene, sigma_aldrich, ""),
+            ChemicalOrder(l_limonene, sigma_aldrich, ""),
+        ]
 
         solvent = Compound(solvent_order, is_solvent=True)
         compounds = [Compound(chemical_order) for chemical_order in chemical_orders]
         n_odorants = len(compounds)
 
         solutions = []
-        solutions.append(Solution({compounds[0]: 1 * pq.mL,
-                                solvent: 24 * pq.mL}))
-        solutions.append(Solution({compounds[1]: 1 * pq.mL,
-                                solvent: 24 * pq.mL}))
-        solutions.append(Solution({compounds[2]: 1 * pq.mL,
-                                solvent: 24 * pq.mL}))
-        solutions.append(Solution({compounds[0]: 0.01 * pq.mL,
-                                solvent: 24 * pq.mL}))
-        solutions.append(Solution({compounds[1]: 0.01 * pq.mL,
-                                solvent: 24.9 * pq.mL}))
-        solutions.append(Solution({compounds[2]: 0.01 * pq.mL,
-                                solvent: 24.9 * pq.mL}))
+        solutions.append(Solution({compounds[0]: 1 * pq.mL, solvent: 24 * pq.mL}))
+        solutions.append(Solution({compounds[1]: 1 * pq.mL, solvent: 24 * pq.mL}))
+        solutions.append(Solution({compounds[2]: 1 * pq.mL, solvent: 24 * pq.mL}))
+        solutions.append(Solution({compounds[0]: 0.01 * pq.mL, solvent: 24 * pq.mL}))
+        solutions.append(Solution({compounds[1]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
+        solutions.append(Solution({compounds[2]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
         n_solutions = len(solutions)

--- a/pyrfume/unit_test/test_make_solutions.py
+++ b/pyrfume/unit_test/test_make_solutions.py
@@ -40,8 +40,6 @@ class MakeSolutionTestCase(unittest.TestCase):
 
         solvent = Compound(solvent_order, is_solvent=True)
         compounds = [Compound(chemical_order) for chemical_order in chemical_orders]
-        n_odorants = len(compounds)
-
         solutions = []
         solutions.append(Solution({compounds[0]: 1 * pq.mL, solvent: 24 * pq.mL}))
         solutions.append(Solution({compounds[1]: 1 * pq.mL, solvent: 24 * pq.mL}))
@@ -49,4 +47,4 @@ class MakeSolutionTestCase(unittest.TestCase):
         solutions.append(Solution({compounds[0]: 0.01 * pq.mL, solvent: 24 * pq.mL}))
         solutions.append(Solution({compounds[1]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
         solutions.append(Solution({compounds[2]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
-        n_solutions = len(solutions)
+

--- a/pyrfume/unit_test/test_make_solutions.py
+++ b/pyrfume/unit_test/test_make_solutions.py
@@ -47,4 +47,3 @@ class MakeSolutionTestCase(unittest.TestCase):
         solutions.append(Solution({compounds[0]: 0.01 * pq.mL, solvent: 24 * pq.mL}))
         solutions.append(Solution({compounds[1]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
         solutions.append(Solution({compounds[2]: 0.01 * pq.mL, solvent: 24.9 * pq.mL}))
-

--- a/pyrfume/unit_test/test_make_solutions.py
+++ b/pyrfume/unit_test/test_make_solutions.py
@@ -1,6 +1,8 @@
-from pyrfume.odorants import Solution, Compound, ChemicalOrder, Vendor, Molecule
-import quantities as pq
 import unittest
+
+import quantities as pq
+
+from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Solution, Vendor
 
 
 class MakeSolutionTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_mixture.py
+++ b/pyrfume/unit_test/test_mixture.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pyrfume.objects import Mixture, Component
 from pyrfume.odorants import Compound, ChemicalOrder, Vendor, Molecule
 
+
 class MixtureTestCase(unittest.TestCase):
     def test_constructor(self):
         mixture1 = Mixture(0)
@@ -21,7 +22,7 @@ class MixtureTestCase(unittest.TestCase):
         molecule = Molecule(cid, "test_mol", True)
         self.assertIsNone(molecule.molarity)
         molecule.molecular_weight = pq.Quantity(502.1, pq.g / pq.mol)
-        molecule.density = pq.Quantity(501.9982, pq.g / pq.cm ** 3)
+        molecule.density = pq.Quantity(501.9982, pq.g / pq.cm**3)
         self.assertAlmostEqual(molecule.molarity.item(), 999.797251, 3)
 
         chemical_order = ChemicalOrder(molecule, vendor, "", 0.9, None)
@@ -40,7 +41,7 @@ class MixtureTestCase(unittest.TestCase):
         mixture1 = Mixture(0)
         self.assertIsNone(mixture1.r(mixture))
         self.assertEqual(mixture.overlap(mixture, True), 100.0)
-        
+
         mixture.add_component(component1)
         mixture.remove_component(component1)
         self.assertEqual(len(mixture.components), 1)
@@ -48,14 +49,14 @@ class MixtureTestCase(unittest.TestCase):
         self.assertEqual(len(mixture.components), 0)
 
         cas_descriptor = {
-            cas : ["cas descriptor"],
-            "dravnieks" : ["dravnieks descriptor"],
-            "sigma_ff" : ["sigma_ff descriptor"]
+            cas: ["cas descriptor"],
+            "dravnieks": ["dravnieks descriptor"],
+            "sigma_ff": ["sigma_ff descriptor"],
         }
         cas_descriptor1 = {
-            cas : {"cas descriptor 1" : 1},
-            "dravnieks" : {"dravnieks cas description 1" : 2},
-            "sigma_ff" : {"sigma_ff descriptor 1"}
+            cas: {"cas descriptor 1": 1},
+            "dravnieks": {"dravnieks cas description 1": 2},
+            "sigma_ff": {"sigma_ff descriptor 1"},
         }
         component.set_descriptors("unittest source", cas_descriptor)
         component1.set_descriptors("unittest source", cas_descriptor1)
@@ -63,18 +64,18 @@ class MixtureTestCase(unittest.TestCase):
         mixture.add_component(component1)
 
         descriptors_list = mixture.descriptor_list("unittest source")
-        self.assertTrue('cas descriptor 1' in descriptors_list)
-        self.assertTrue('cas descriptor' in descriptors_list)
+        self.assertTrue("cas descriptor 1" in descriptors_list)
+        self.assertTrue("cas descriptor" in descriptors_list)
 
         all_descriptors = {
-            'unittest source' : 'cas descriptor 1', 
-            'unittest source' : 'cas descriptor'
+            "unittest source": "cas descriptor 1",
+            "unittest source": "cas descriptor",
         }
         self.assertEqual(mixture.descriptor_vector("unittest source", all_descriptors).size, 14)
-        
+
         all_descriptors = {
-            'dravnieks' : "dravnieks cas description 1", 
-            'sigma_ff' : "sigma_ff descriptor 1"
+            "dravnieks": "dravnieks cas description 1",
+            "sigma_ff": "sigma_ff descriptor 1",
         }
 
         self.assertEqual(mixture.descriptor_vector2(all_descriptors).size, 48)
@@ -88,7 +89,7 @@ class MixtureTestCase(unittest.TestCase):
 
         self.assertEqual(mixture.fraction_components_described("unittest source"), 1)
 
-        test_feature = {cid : {"a" : 1}}
+        test_feature = {cid: {"a": 1}}
         self.assertEqual(mixture.matrix(test_feature).shape, (2, 1))
         self.assertEqual(mixture.vector(test_feature)[0], 2.0)
         self.assertIsInstance(str(mixture), str)
@@ -98,5 +99,6 @@ class MixtureTestCase(unittest.TestCase):
         self.assertIsInstance(str(component), str)
         self.assertIsInstance(str(component1), str)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_mixture.py
+++ b/pyrfume/unit_test/test_mixture.py
@@ -70,7 +70,6 @@ class MixtureTestCase(unittest.TestCase):
         self.assertTrue("cas descriptor" in descriptors_list)
 
         all_descriptors = {
-            "unittest source": "cas descriptor 1",
             "unittest source": "cas descriptor",
         }
         self.assertEqual(mixture.descriptor_vector("unittest source", all_descriptors).size, 14)

--- a/pyrfume/unit_test/test_mixture.py
+++ b/pyrfume/unit_test/test_mixture.py
@@ -1,8 +1,10 @@
 import unittest
-import quantities as pq
 from datetime import datetime
-from pyrfume.objects import Mixture, Component
-from pyrfume.odorants import Compound, ChemicalOrder, Vendor, Molecule
+
+import quantities as pq
+
+from pyrfume.objects import Component, Mixture
+from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Vendor
 
 
 class MixtureTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_odorants.py
+++ b/pyrfume/unit_test/test_odorants.py
@@ -6,15 +6,30 @@ import time
 import quantities as pq
 from quantities.units.velocity import speed_of_light
 from pyrfume import save_data, set_data_path, get_data_path
-from pyrfume.odorants import url_to_json, Solution, get_cid, \
-                            get_cids, from_cids, cids_to_cas, \
-                            cids_to_smiles, cactus, cactus_image, \
-                            get_compound_summary, get_compound_odor, \
-                            _parse_other_info, smiles_to_image, crop_image, \
-                            all_odorants, all_sources, all_cids, all_smiles
-                            
+from pyrfume.odorants import (
+    url_to_json,
+    Solution,
+    get_cid,
+    get_cids,
+    from_cids,
+    cids_to_cas,
+    cids_to_smiles,
+    cactus,
+    cactus_image,
+    get_compound_summary,
+    get_compound_odor,
+    _parse_other_info,
+    smiles_to_image,
+    crop_image,
+    all_odorants,
+    all_sources,
+    all_cids,
+    all_smiles,
+)
+
 
 from . import unittest_utils
+
 unittest_utils.DELAY = 5
 from .unittest_utils import get_substances
 
@@ -22,11 +37,11 @@ from .unittest_utils import get_substances
 class OdorantsTestCase(unittest.TestCase):
     def setUp(self):
         self.compound_C4H8O2, self.compound_C4H8S, self.compound_C2H6O = get_substances("compounds")
-        
+
         self.compounds = {
-            self.compound_C4H8O2 : 100 * pq.mL,
-            self.compound_C4H8S : 100 * pq.mL,
-            self.compound_C2H6O : 100 * pq.mL
+            self.compound_C4H8O2: 100 * pq.mL,
+            self.compound_C4H8S: 100 * pq.mL,
+            self.compound_C2H6O: 100 * pq.mL,
         }
 
     def test_solution(self):
@@ -39,15 +54,15 @@ class OdorantsTestCase(unittest.TestCase):
         for compound in self.compounds.keys():
             self.assertTrue(compound in solution.compounds)
 
-        components = {solution : 100 * pq.mL}
+        components = {solution: 100 * pq.mL}
         solution = Solution(components, None)
         for compound in self.compounds.keys():
             self.assertTrue(compound in solution.compounds)
-        
+
         molecule_C4H8O2 = self.compound_C4H8O2.chemical_order.molecule
         molecule_C4H8S = self.compound_C4H8S.chemical_order.molecule
         molecule_C2H6O = self.compound_C2H6O.chemical_order.molecule
-        
+
         self.assertAlmostEqual(solution.molecules[molecule_C4H8O2].item(), 1.02376683, 3)
         self.assertAlmostEqual(solution.molecules[molecule_C4H8S].item(), 1.1307701, 3)
         self.assertAlmostEqual(solution.molecules[molecule_C2H6O].item(), 1.71329962, 3)
@@ -70,9 +85,15 @@ class OdorantsTestCase(unittest.TestCase):
         self.assertAlmostEqual(solution.vapor_concentration(molecule_C4H8S), 0.006924697, 3)
         self.assertAlmostEqual(solution.vapor_concentration(molecule_C2H6O), 0.034562520, 3)
 
-        self.assertAlmostEqual(solution.molar_evaporation_rate(molecule_C4H8O2).item(), 0.00116778, 3)
-        self.assertAlmostEqual(solution.molar_evaporation_rate(molecule_C4H8S).item(), 0.00023938, 3)
-        self.assertAlmostEqual(solution.molar_evaporation_rate(molecule_C2H6O).item(), 0.00122993, 3)
+        self.assertAlmostEqual(
+            solution.molar_evaporation_rate(molecule_C4H8O2).item(), 0.00116778, 3
+        )
+        self.assertAlmostEqual(
+            solution.molar_evaporation_rate(molecule_C4H8S).item(), 0.00023938, 3
+        )
+        self.assertAlmostEqual(
+            solution.molar_evaporation_rate(molecule_C2H6O).item(), 0.00122993, 3
+        )
 
     def test_molecular(self):
         molecule_C4H8O2_1, molecule_C4H8S_1, molecule_C2H6O_1 = get_substances("molecules")
@@ -90,7 +111,9 @@ class OdorantsTestCase(unittest.TestCase):
         self.assertIsInstance(repr(molecule_C2H6O_1), str)
 
     def test_url_to_json(self):
-        json_dict = url_to_json("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/962/synonyms/JSON")
+        json_dict = url_to_json(
+            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/962/synonyms/JSON"
+        )
         self.assertEqual(json_dict["InformationList"]["Information"][0]["Synonym"][0], "water")
 
     def test_get_cid(self):
@@ -98,43 +121,43 @@ class OdorantsTestCase(unittest.TestCase):
         self.assertEqual(get_cid("141-78-6"), 8857)
         self.assertEqual(get_cid("110-01-0"), 1127)
 
-        cids = get_cids(["64-17-5",  "141-78-6", "110-01-0"])
+        cids = get_cids(["64-17-5", "141-78-6", "110-01-0"])
         self.assertEqual(cids["64-17-5"], 702)
         self.assertEqual(cids["141-78-6"], 8857)
         self.assertEqual(cids["110-01-0"], 1127)
 
     def test_from_cids(self):
         results = from_cids([702, 8857, 1127])
-        self.assertEqual(results[0]['IUPACName'], 'ethanol')
-        self.assertEqual(results[1]['IUPACName'], 'ethyl acetate')
-        self.assertEqual(results[2]['IUPACName'], 'thiolane')
+        self.assertEqual(results[0]["IUPACName"], "ethanol")
+        self.assertEqual(results[1]["IUPACName"], "ethyl acetate")
+        self.assertEqual(results[2]["IUPACName"], "thiolane")
 
     def test_cids_to_smiles(self):
         results = cids_to_smiles([702, 8857, 1127])
-        self.assertEqual(results[702], 'CCO')
-        self.assertEqual(results[8857], 'CCOC(=O)C')
-        self.assertEqual(results[1127], 'C1CCSC1')
+        self.assertEqual(results[702], "CCO")
+        self.assertEqual(results[8857], "CCOC(=O)C")
+        self.assertEqual(results[1127], "C1CCSC1")
 
     def test_cids_to_cas(self):
         results = cids_to_cas([702, 8857, 1127])
-        self.assertEqual(results[702][0], '64-17-5')
-        self.assertEqual(results[8857][0], '141-78-6')
-        self.assertEqual(results[1127][0], '110-01-0')
+        self.assertEqual(results[702][0], "64-17-5")
+        self.assertEqual(results[8857][0], "141-78-6")
+        self.assertEqual(results[1127][0], "110-01-0")
 
     def test_cactus(self):
         results = cactus("Ethyl acetate", "cas").split("\n")
         self.assertTrue("141-78-6" in results)
 
-        results = cactus("Ethanol", "cas").split('\n')
+        results = cactus("Ethanol", "cas").split("\n")
         self.assertTrue("64-17-5" in results)
 
-        results = cactus("Tetrahydrothiophene", "cas").split('\n')
+        results = cactus("Tetrahydrothiophene", "cas").split("\n")
         self.assertTrue("110-01-0" in results)
 
     def test_get_compound_summary(self):
-        self.assertIsInstance(get_compound_summary(702, 'Physical Description'), dict)
-        self.assertIsInstance(get_compound_summary(8857, 'Physical Description'), dict)
-        self.assertIsInstance(get_compound_summary(1127, 'Physical Description'), dict)
+        self.assertIsInstance(get_compound_summary(702, "Physical Description"), dict)
+        self.assertIsInstance(get_compound_summary(8857, "Physical Description"), dict)
+        self.assertIsInstance(get_compound_summary(1127, "Physical Description"), dict)
 
     def test_get_compound_odor(self):
         self.assertIsInstance(get_compound_odor(702, False), list)
@@ -148,20 +171,20 @@ class OdorantsTestCase(unittest.TestCase):
         self.assertTrue(len(_parse_other_info(None)) == 0)
 
         test_info_dict = {
-            "String" : "value of String",
-            "Value" : "Number 0",
-            "Dict" : {"String" : "value of String in the sub-dict"}
+            "String": "value of String",
+            "Value": "Number 0",
+            "Dict": {"String": "value of String in the sub-dict"},
         }
         result = _parse_other_info(test_info_dict)
-        self.assertTrue('value of String' in result)
-        self.assertTrue('Number 0' in result)
-        self.assertTrue('value of String in the sub-dict' in result)
+        self.assertTrue("value of String" in result)
+        self.assertTrue("Number 0" in result)
+        self.assertTrue("value of String in the sub-dict" in result)
 
         test_info_list = [test_info_dict]
         result = _parse_other_info(test_info_list)
-        self.assertTrue('value of String' in result)
-        self.assertTrue('Number 0' in result)
-        self.assertTrue('value of String in the sub-dict' in result)
+        self.assertTrue("value of String" in result)
+        self.assertTrue("Number 0" in result)
+        self.assertTrue("value of String in the sub-dict" in result)
 
     @unittest.skip("Failure expected. A fix is needed.")
     def test_cactus_image(self):
@@ -170,11 +193,13 @@ class OdorantsTestCase(unittest.TestCase):
     @unittest.skip("Failure expected. The data is needed for this test case.")
     def test_all_items(self):
         from pandas import DataFrame
-        #set_data_path('C:/icon/pyrfume')
+
+        # set_data_path('C:/icon/pyrfume')
         self.assertIsInstance(all_odorants(), DataFrame)
         self.assertIsInstance(all_sources(), DataFrame)
         self.assertIsInstance(all_cids(), list)
         self.assertIsInstance(all_smiles(), list)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_odorants.py
+++ b/pyrfume/unit_test/test_odorants.py
@@ -24,7 +24,9 @@ from pyrfume.odorants import (
 from . import unittest_utils
 
 unittest_utils.DELAY = 5
-from .unittest_utils import get_substances  # noqa: E402 (TODO: this should be designed differently in my opinion)
+from .unittest_utils import (  # noqa: E402 (TODO: this should be designed differently in my opinion)
+    get_substances,
+)
 
 
 class OdorantsTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_odorants.py
+++ b/pyrfume/unit_test/test_odorants.py
@@ -1,32 +1,32 @@
 import json
-import unittest
 import random
 import time
+import unittest
 
 import quantities as pq
 from quantities.units.velocity import speed_of_light
-from pyrfume import save_data, set_data_path, get_data_path
+
+from pyrfume import get_data_path, save_data, set_data_path
 from pyrfume.odorants import (
-    url_to_json,
     Solution,
-    get_cid,
-    get_cids,
-    from_cids,
-    cids_to_cas,
-    cids_to_smiles,
+    _parse_other_info,
+    all_cids,
+    all_odorants,
+    all_smiles,
+    all_sources,
     cactus,
     cactus_image,
-    get_compound_summary,
-    get_compound_odor,
-    _parse_other_info,
-    smiles_to_image,
+    cids_to_cas,
+    cids_to_smiles,
     crop_image,
-    all_odorants,
-    all_sources,
-    all_cids,
-    all_smiles,
+    from_cids,
+    get_cid,
+    get_cids,
+    get_compound_odor,
+    get_compound_summary,
+    smiles_to_image,
+    url_to_json,
 )
-
 
 from . import unittest_utils
 

--- a/pyrfume/unit_test/test_odorants.py
+++ b/pyrfume/unit_test/test_odorants.py
@@ -1,12 +1,7 @@
-import json
-import random
-import time
 import unittest
 
 import quantities as pq
-from quantities.units.velocity import speed_of_light
 
-from pyrfume import get_data_path, save_data, set_data_path
 from pyrfume.odorants import (
     Solution,
     _parse_other_info,
@@ -18,20 +13,18 @@ from pyrfume.odorants import (
     cactus_image,
     cids_to_cas,
     cids_to_smiles,
-    crop_image,
     from_cids,
     get_cid,
     get_cids,
     get_compound_odor,
     get_compound_summary,
-    smiles_to_image,
     url_to_json,
 )
 
 from . import unittest_utils
 
 unittest_utils.DELAY = 5
-from .unittest_utils import get_substances
+from .unittest_utils import get_substances  # noqa: E402 (TODO: this should be designed differently in my opinion)
 
 
 class OdorantsTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_others_in__init__.py
+++ b/pyrfume/unit_test/test_others_in__init__.py
@@ -1,8 +1,14 @@
 import unittest
 import numpy as np
-from pyrfume.experiments import Distance, Result, odorant_distances, ROC, correct_matrix, TriangleTest
+from pyrfume.experiments import (
+    Distance,
+    Result,
+    odorant_distances,
+    ROC,
+    correct_matrix,
+    TriangleTest,
+)
 from .unittest_utils import get_substances
-
 
 
 class OthersTestCase(unittest.TestCase):
@@ -19,7 +25,7 @@ class OthersTestCase(unittest.TestCase):
         test1 = TriangleTest(0, list(self.mixtures), 0.5, True)
         new_odorants = [self.mixture_C4H8O2, self.mixture_C2H6O, self.mixture_C2H6O]
         test1.add_odorants(new_odorants)
-        
+
         test2 = TriangleTest(1, list(self.mixtures), 0.5, False)
         new_odorants = [self.mixture_C4H8O2, self.mixture_C4H8S, self.mixture_C4H8S]
         test2.add_odorants(new_odorants)
@@ -31,11 +37,12 @@ class OthersTestCase(unittest.TestCase):
         distances: dict = odorant_distances(results, 0)
         self.assertTrue(1 in distances.values())
         self.assertTrue(0 in distances.values())
-        
+
         roc = ROC(results, 1)
         self.assertEqual(roc[0][0], 1)
         self.assertEqual(roc[1][0], 1)
         matrix = correct_matrix(results, 1, None)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_others_in__init__.py
+++ b/pyrfume/unit_test/test_others_in__init__.py
@@ -1,6 +1,5 @@
 import unittest
 
-
 from pyrfume.experiments import (
     ROC,
     Distance,

--- a/pyrfume/unit_test/test_others_in__init__.py
+++ b/pyrfume/unit_test/test_others_in__init__.py
@@ -1,6 +1,5 @@
 import unittest
 
-import numpy as np
 
 from pyrfume.experiments import (
     ROC,
@@ -22,7 +21,7 @@ class OthersTestCase(unittest.TestCase):
         self.component_C4H8O2, self.component_C4H8S, self.component_C2H6O = self.components
 
     def test_Distance(self):
-        distance = Distance(self.mixture_C4H8O2, self.mixture_C2H6O, 1.0)
+        Distance(self.mixture_C4H8O2, self.mixture_C2H6O, 1.0)
 
     def test_odorant_distances_ROC_correct_matrix(self):
         test1 = TriangleTest(0, list(self.mixtures), 0.5, True)
@@ -44,7 +43,7 @@ class OthersTestCase(unittest.TestCase):
         roc = ROC(results, 1)
         self.assertEqual(roc[0][0], 1)
         self.assertEqual(roc[1][0], 1)
-        matrix = correct_matrix(results, 1, None)
+        correct_matrix(results, 1, None)
 
 
 if __name__ == "__main__":

--- a/pyrfume/unit_test/test_others_in__init__.py
+++ b/pyrfume/unit_test/test_others_in__init__.py
@@ -1,13 +1,16 @@
 import unittest
+
 import numpy as np
+
 from pyrfume.experiments import (
+    ROC,
     Distance,
     Result,
-    odorant_distances,
-    ROC,
-    correct_matrix,
     TriangleTest,
+    correct_matrix,
+    odorant_distances,
 )
+
 from .unittest_utils import get_substances
 
 

--- a/pyrfume/unit_test/test_physics.py
+++ b/pyrfume/unit_test/test_physics.py
@@ -2,7 +2,7 @@ import unittest
 
 import quantities as pq
 
-from pyrfume.physics import *
+from pyrfume.physics import bernoulli, mackay, Symbol, venturi
 
 
 class PhysicsTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_physics.py
+++ b/pyrfume/unit_test/test_physics.py
@@ -2,7 +2,7 @@ import unittest
 
 import quantities as pq
 
-from pyrfume.physics import bernoulli, mackay, Symbol, venturi
+from pyrfume.physics import Symbol, bernoulli, mackay, venturi
 
 
 class PhysicsTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_physics.py
+++ b/pyrfume/unit_test/test_physics.py
@@ -1,6 +1,8 @@
 import unittest
-from pyrfume.physics import *
+
 import quantities as pq
+
+from pyrfume.physics import *
 
 
 class PhysicsTestCase(unittest.TestCase):

--- a/pyrfume/unit_test/test_physics.py
+++ b/pyrfume/unit_test/test_physics.py
@@ -2,45 +2,53 @@ import unittest
 from pyrfume.physics import *
 import quantities as pq
 
+
 class PhysicsTestCase(unittest.TestCase):
     def test_mackay(self):
         q = 1 * pq.Pa
         self.assertAlmostEqual(2.8238e-07, mackay(q).item(), 3)
         q = -1 * pq.Pa
         self.assertEqual(0, mackay(q).item())
-    
+
     def test_bernoulli(self):
         bernoulli()
-        bernoulli(1 * pq.m/pq.s)
-        bernoulli(1 * pq.m/pq.s, 1 * pq.Pa)
-        bernoulli(1 * pq.m/pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm ** 3)
-        bernoulli(1 * pq.m/pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm ** 3, 3.72076 * pq.m / (pq.s) ** 2)
-        bernoulli(1 * pq.m/pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm ** 3, 3.72076 * pq.m / (pq.s) ** 2, 1)
+        bernoulli(1 * pq.m / pq.s)
+        bernoulli(1 * pq.m / pq.s, 1 * pq.Pa)
+        bernoulli(1 * pq.m / pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm**3)
+        bernoulli(1 * pq.m / pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm**3, 3.72076 * pq.m / (pq.s) ** 2)
+        bernoulli(
+            1 * pq.m / pq.s, 1 * pq.Pa, 1 * pq.g / pq.cm**3, 3.72076 * pq.m / (pq.s) ** 2, 1
+        )
         self.assertEqual(
             bernoulli(
-                1 * pq.m/pq.s, 
-                1 * pq.Pa, 
-                1 * pq.g / pq.cm ** 3, 
-                3.72076 * pq.m / (pq.s) ** 2, 
-                1, 
-                1 * (pq.m / pq.s) ** 2
+                1 * pq.m / pq.s,
+                1 * pq.Pa,
+                1 * pq.g / pq.cm**3,
+                3.72076 * pq.m / (pq.s) ** 2,
+                1,
+                1 * (pq.m / pq.s) ** 2,
             ),
-            []
+            [],
         )
 
     def test_venturi(self):
-        venturi(1 * pq.g / pq.cm ** 3)
-        venturi(1 * pq.g / pq.cm ** 3, 1 * pq.Pa)
-        venturi(1 * pq.g / pq.cm ** 3, 1 * pq.Pa, 2 * pq.Pa, )
+        venturi(1 * pq.g / pq.cm**3)
+        venturi(1 * pq.g / pq.cm**3, 1 * pq.Pa)
+        venturi(
+            1 * pq.g / pq.cm**3,
+            1 * pq.Pa,
+            2 * pq.Pa,
+        )
 
         v2 = Symbol("v2", real=True, positive=True)
-        result = venturi(1 * pq.g / pq.cm ** 3, 1 * pq.Pa, 2 * pq.Pa, 1 * pq.m / pq.s)[0][v2]
+        result = venturi(1 * pq.g / pq.cm**3, 1 * pq.Pa, 2 * pq.Pa, 1 * pq.m / pq.s)[0][v2]
         self.assertAlmostEqual(result, 0.998999, 4)
 
-        result = venturi(1 * pq.g / pq.cm ** 3, 1 * pq.Pa, 2 * pq.Pa, 1 * pq.m / pq.s, 2 * pq.m / pq.s)
+        result = venturi(
+            1 * pq.g / pq.cm**3, 1 * pq.Pa, 2 * pq.Pa, 1 * pq.m / pq.s, 2 * pq.m / pq.s
+        )
         self.assertEqual(result, [])
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/test_test.py
+++ b/pyrfume/unit_test/test_test.py
@@ -1,9 +1,6 @@
 import unittest
-from datetime import datetime
 
 from pyrfume.experiments import Result, TriangleTest
-from pyrfume.objects import Component, Mixture
-from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Vendor
 
 from .unittest_utils import get_substances
 
@@ -11,7 +8,7 @@ from .unittest_utils import get_substances
 class TriangleTestTestCase(unittest.TestCase):
     def test_test(self):
 
-        mixture_C4H8O2, mixture_C4H8S, mixture_C2H6O = get_substances("mixtures")
+        mixture_C4H8O2, _, mixture_C2H6O = get_substances("mixtures")
         component_C4H8O2, component_C4H8S, component_C2H6O = get_substances("components")
 
         odorants = [mixture_C4H8O2]

--- a/pyrfume/unit_test/test_test.py
+++ b/pyrfume/unit_test/test_test.py
@@ -1,9 +1,9 @@
 import unittest
-
-from pyrfume.odorants import Compound, ChemicalOrder, Vendor, Molecule
-from pyrfume.experiments import TriangleTest, Result
-from pyrfume.objects import Component, Mixture
 from datetime import datetime
+
+from pyrfume.experiments import Result, TriangleTest
+from pyrfume.objects import Component, Mixture
+from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Vendor
 
 from .unittest_utils import get_substances
 

--- a/pyrfume/unit_test/test_test.py
+++ b/pyrfume/unit_test/test_test.py
@@ -7,8 +7,8 @@ from datetime import datetime
 
 from .unittest_utils import get_substances
 
-class TriangleTestTestCase(unittest.TestCase):
 
+class TriangleTestTestCase(unittest.TestCase):
     def test_test(self):
 
         mixture_C4H8O2, mixture_C4H8S, mixture_C2H6O = get_substances("mixtures")
@@ -24,13 +24,12 @@ class TriangleTestTestCase(unittest.TestCase):
         self.assertEqual(mixture_C4H8O2, test.single)
         self.assertEqual(mixture_C2H6O, test.pair[0])
         self.assertEqual(mixture_C4H8O2, test.pair[1])
-        
 
         odorants = [mixture_C4H8O2]
 
         test = TriangleTest(0, odorants, 1.0, True)
         test.add_odorants([mixture_C2H6O, mixture_C2H6O])
-        
+
         self.assertEqual(mixture_C2H6O, test.double)
         self.assertEqual(mixture_C4H8O2, test.single)
         self.assertEqual(mixture_C2H6O, test.pair[0])
@@ -39,40 +38,40 @@ class TriangleTestTestCase(unittest.TestCase):
         self.assertEqual(1, test.N)
         self.assertEqual(1, test.r)
         self.assertEqual(0, test.overlap(False))
-        self.assertEqual(0, test.overlap(True))        
+        self.assertEqual(0, test.overlap(True))
 
-        self.assertTrue("common descriptor" in test.common_descriptors('unittest source'))
-        self.assertTrue("C2H6O unique descriptor" in test.unique_descriptors('unittest source'))
-        self.assertTrue("C4H8O2 unique descriptor" in test.unique_descriptors('unittest source'))
+        self.assertTrue("common descriptor" in test.common_descriptors("unittest source"))
+        self.assertTrue("C2H6O unique descriptor" in test.unique_descriptors("unittest source"))
+        self.assertTrue("C4H8O2 unique descriptor" in test.unique_descriptors("unittest source"))
         all_descriptors = {
-            'unittest source' : [
-                'C2H6O unique descriptor', 
-                'C4H8O2 unique descriptor',
-                "common descriptor"
+            "unittest source": [
+                "C2H6O unique descriptor",
+                "C4H8O2 unique descriptor",
+                "common descriptor",
             ],
-            "dravnieks" : [
+            "dravnieks": [
                 "C2H6O dravnieks descriptor",
                 "C4H8S dravnieks descriptor",
-                "C4H8O2 dravnieks descriptor", 
-                "common dravnieks descriptor"
+                "C4H8O2 dravnieks descriptor",
+                "common dravnieks descriptor",
             ],
-            "sigma_ff" : [
+            "sigma_ff": [
                 "C2H6O sigma_ff descriptor",
                 "C4H8S sigma_ff descriptor",
-                "C4H8O2 sigma_ff descriptor", 
-                "common sigma_ff descriptor"
-            ]
+                "C4H8O2 sigma_ff descriptor",
+                "common sigma_ff descriptor",
+            ],
         }
         self.assertAlmostEqual(
-            test.descriptors_correlation('unittest source', all_descriptors), -0.5, 2
+            test.descriptors_correlation("unittest source", all_descriptors), -0.5, 2
         )
 
         self.assertAlmostEqual(
-            test.descriptors_correlation('unittest source', all_descriptors), -0.5, 2
+            test.descriptors_correlation("unittest source", all_descriptors), -0.5, 2
         )
 
         test.descriptors_correlation2(all_descriptors)
-        diff_list = list(test.descriptors_difference('unittest source', all_descriptors))
+        diff_list = list(test.descriptors_difference("unittest source", all_descriptors))
         self.assertEqual(diff_list.count(1.0), 2)
         self.assertEqual(diff_list.count(0), 1)
 
@@ -86,7 +85,7 @@ class TriangleTestTestCase(unittest.TestCase):
         self.assertTrue(component_C4H8S in test.common_components)
         self.assertTrue(str(component_C2H6O) in unique_components)
         self.assertTrue(str(component_C4H8O2) in unique_components)
-        self.assertEqual(test.n_undescribed('unittest source'), (0, 0))
+        self.assertEqual(test.n_undescribed("unittest source"), (0, 0))
 
         result1 = Result(test, 0, True)
         results = [result1]
@@ -97,5 +96,6 @@ class TriangleTestTestCase(unittest.TestCase):
         results.append(result2)
         self.assertEqual(test.fraction_correct(results), 0.5)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/pyrfume/unit_test/unittest_utils.py
+++ b/pyrfume/unit_test/unittest_utils.py
@@ -13,19 +13,19 @@ def get_water(substance_type: str = "mixtures"):
     cid_H2O = 962
     cas_H2O = "7732-18-5"
     molecule_H2O = Molecule(cid_H2O, "Water", True, delay=DELAY)
-    molecule_H2O.density = 	0.902 * pq.g / pq.mL
-    molecule_H2O.molecular_weight = 	88.106 * pq.g / pq.mol
+    molecule_H2O.density = 0.902 * pq.g / pq.mL
+    molecule_H2O.molecular_weight = 88.106 * pq.g / pq.mol
     molecule_H2O.cas = cas_H2O
     chemical_order_molecule_H2O = ChemicalOrder(molecule_H2O, vendor, "part 0", 0.5, None)
     compound_H2O = Compound(chemical_order_molecule_H2O, "TEST", datetime.now, datetime.now, True)
     component_H2O = Component(cid_H2O, "H2O", cas_H2O, 0.5, compound_H2O)
     mixture_H2O = Mixture(2, [component_H2O])
     descriptors = {
-        cas_H2O : ["H2O unique descriptor", "common descriptor"],
-        "dravnieks" : ["H2O dravnieks descriptor", "common dravnieks descriptor"],
-        "sigma_ff" : ["H2O sigma_ff descriptor", "common sigma_ff descriptor"]
+        cas_H2O: ["H2O unique descriptor", "common descriptor"],
+        "dravnieks": ["H2O dravnieks descriptor", "common dravnieks descriptor"],
+        "sigma_ff": ["H2O sigma_ff descriptor", "common sigma_ff descriptor"],
     }
-    component_H2O.set_descriptors('unittest source', descriptors)
+    component_H2O.set_descriptors("unittest source", descriptors)
 
     if substance_type == "mixtures":
         return mixture_H2O
@@ -45,20 +45,22 @@ def get_substances(substance_type: str = "mixtures"):
     cid_C4H8O2 = 8857
     cas_C4H8O2 = "141-78-6"
     molecule_C4H8O2 = Molecule(cid_C4H8O2, "Ethyl acetate", True, delay=DELAY)
-    molecule_C4H8O2.density = 	0.902 * pq.g / pq.mL
-    molecule_C4H8O2.molecular_weight = 	88.106 * pq.g / pq.mol
+    molecule_C4H8O2.density = 0.902 * pq.g / pq.mL
+    molecule_C4H8O2.molecular_weight = 88.106 * pq.g / pq.mol
     molecule_C4H8O2.vapor_pressure = 12.425 * pq.kPa
     molecule_C4H8O2.cas = cas_C4H8O2
     chemical_order_molecule_C4H8O2 = ChemicalOrder(molecule_C4H8O2, vendor, "part 0", 0.5, None)
-    compound_C4H8O2 = Compound(chemical_order_molecule_C4H8O2, "TEST", datetime.now, datetime.now, False)
+    compound_C4H8O2 = Compound(
+        chemical_order_molecule_C4H8O2, "TEST", datetime.now, datetime.now, False
+    )
     component_C4H8O2 = Component(cid_C4H8O2, "C4H8O2", cas_C4H8O2, 0.5, compound_C4H8O2)
     mixture_C4H8O2 = Mixture(2, [component_C4H8O2])
     descriptors = {
-        cas_C4H8O2 : ["C4H8O2 unique descriptor", "common descriptor"],
-        "dravnieks" : ["C4H8O2 dravnieks descriptor", "common dravnieks descriptor"],
-        "sigma_ff" : ["C4H8O2 sigma_ff descriptor", "common sigma_ff descriptor"]
+        cas_C4H8O2: ["C4H8O2 unique descriptor", "common descriptor"],
+        "dravnieks": ["C4H8O2 dravnieks descriptor", "common dravnieks descriptor"],
+        "sigma_ff": ["C4H8O2 sigma_ff descriptor", "common sigma_ff descriptor"],
     }
-    component_C4H8O2.set_descriptors('unittest source', descriptors)
+    component_C4H8O2.set_descriptors("unittest source", descriptors)
 
     cid_C2H6O = 702
     cas_C2H6O = "64-17-5"
@@ -72,11 +74,11 @@ def get_substances(substance_type: str = "mixtures"):
     component_C2H6O = Component(cid_C2H6O, "C2H6O", cas_C2H6O, 0.5, compound_C2H6O)
     mixture_C2H6O = Mixture(2, [component_C2H6O])
     descriptors = {
-        cas_C2H6O : ["C2H6O unique descriptor", "common descriptor"],
-        "dravnieks" : ["C2H6O dravnieks descriptor", "common dravnieks descriptor"],
-        "sigma_ff" : ["C2H6O sigma_ff descriptor", "common sigma_ff descriptor"]
+        cas_C2H6O: ["C2H6O unique descriptor", "common descriptor"],
+        "dravnieks": ["C2H6O dravnieks descriptor", "common dravnieks descriptor"],
+        "sigma_ff": ["C2H6O sigma_ff descriptor", "common sigma_ff descriptor"],
     }
-    component_C2H6O.set_descriptors('unittest source', descriptors)
+    component_C2H6O.set_descriptors("unittest source", descriptors)
 
     cid_C4H8S = 1127
     cas_C4H8S = "110-01-0"
@@ -90,11 +92,11 @@ def get_substances(substance_type: str = "mixtures"):
     mixture_C4H8S = Mixture(2, [component_C4H8S])
 
     descriptors = {
-        cas_C4H8S : ["C4H8S unique descriptor", "common descriptor"],
-        "dravnieks" : ["C4H8S dravnieks descriptor", "common dravnieks descriptor"],
-        "sigma_ff" : ["C4H8S sigma_ff descriptor", "common sigma_ff descriptor"]
+        cas_C4H8S: ["C4H8S unique descriptor", "common descriptor"],
+        "dravnieks": ["C4H8S dravnieks descriptor", "common dravnieks descriptor"],
+        "sigma_ff": ["C4H8S sigma_ff descriptor", "common sigma_ff descriptor"],
     }
-    component_C4H8S.set_descriptors('unittest source', descriptors)
+    component_C4H8S.set_descriptors("unittest source", descriptors)
 
     if substance_type == "mixtures":
         return (mixture_C4H8O2, mixture_C4H8S, mixture_C2H6O)

--- a/pyrfume/unit_test/unittest_utils.py
+++ b/pyrfume/unit_test/unittest_utils.py
@@ -1,8 +1,10 @@
-from pyrfume.odorants import Compound, ChemicalOrder, Vendor, Molecule
+from datetime import datetime
+
+import quantities as pq
+
 from pyrfume.experiments import TriangleTest
 from pyrfume.objects import Component, Mixture
-from datetime import datetime
-import quantities as pq
+from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Vendor
 
 DELAY = 5  # Delay for URL requests to avoid getting throttled by PubChem
 

--- a/pyrfume/unit_test/unittest_utils.py
+++ b/pyrfume/unit_test/unittest_utils.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import quantities as pq
 
-from pyrfume.experiments import TriangleTest
 from pyrfume.objects import Component, Mixture
 from pyrfume.odorants import ChemicalOrder, Compound, Molecule, Vendor
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 import setuptools
 
-setuptools.setup(name='pyrfume')
+setuptools.setup(name="pyrfume")


### PR DESCRIPTION
From the issue raised at #38 about missing `nbconvert`, I ended up needing to convert the GitHub Action workflow into one that uses `poetry` in order for all dependencies to install properly. There were a few complications with this, primarily version incompatibilities, which required some further version constraints in `pyproject.toml` in order to be resolved. I actually solved a failing a test from my previous PR at #37 by upgrading `pandas`, but that required constraining `python`. For better coverage, I included `macos-latest` as a runtime in the action, which appears to only fail with `python3.7`. You can see the logs of the most recent runs [here](https://github.com/schradert/pyrfume/actions/runs/3070812567). I wasn't sure how to resolve the one failing test honestly. I tested the same URL with `requests` on my macOS in `python3.7` and it worked just fine. As it stands though, the build satisfies the constraints previously in place.